### PR TITLE
[GráficoInfo] Aceita html na fonte e corrige largura

### DIFF
--- a/componentes/GraficoInfo/GraficoInfo.jsx
+++ b/componentes/GraficoInfo/GraficoInfo.jsx
@@ -15,7 +15,10 @@ const GraficoInfo = ({
     destaque
 }) => {
     return (
-        <div className={ style.GraficoInfo }>
+        <div className={ cx(
+            style.GraficoInfo,
+            link ? style.DuasColunas : style.UmaColuna
+        ) }>
 
             <div className={ style.TituloContainer }>
                 <h5 className={ cx(style.Titulo, destaque && style.TituloMargem) }>{ titulo }</h5>

--- a/componentes/GraficoInfo/GraficoInfo.jsx
+++ b/componentes/GraficoInfo/GraficoInfo.jsx
@@ -36,7 +36,7 @@ const GraficoInfo = ({
 
             <div className={ style.InfoContainer }>
                 { descricao && <p className={ style.Descricao } dangerouslySetInnerHTML={ { __html: sanitize(descricao) } }></p> }
-                { fonte && <p className={ style.Fonte }>{ fonte }</p> }
+                { fonte && <p className={ style.Fonte } dangerouslySetInnerHTML={ { __html: sanitize(fonte) } }></p> }
             </div>
 
             { link && (

--- a/componentes/GraficoInfo/GraficoInfo.module.css
+++ b/componentes/GraficoInfo/GraficoInfo.module.css
@@ -17,7 +17,7 @@
 }
 
 .DuasColunas {
-    grid-template-columns: 2fr 0.5fr;
+    grid-template-columns: 2fr 1fr;
 }
 
 .TituloContainer {

--- a/componentes/GraficoInfo/GraficoInfo.module.css
+++ b/componentes/GraficoInfo/GraficoInfo.module.css
@@ -7,10 +7,17 @@
     letter-spacing: -2%;
     width: 100%;
     display: grid;
-    grid-template-columns: 2fr 1fr;
     column-gap: 20px;
     row-gap: 10px;
     padding: 30px 0;
+}
+
+.UmaColuna {
+    grid-template-columns: 1fr;
+}
+
+.DuasColunas {
+    grid-template-columns: 2fr 0.5fr;
 }
 
 .TituloContainer {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@impulsogov/design-system",
-  "version": "1.0.73",
+  "version": "1.0.74",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@impulsogov/design-system",
-      "version": "1.0.73",
+      "version": "1.0.74",
       "dependencies": {
         "@babel/cli": "^7.18.9",
         "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@impulsogov/design-system",
   "description": "Impulso Gov Design System",
-  "version": "1.0.73",
+  "version": "1.0.74",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [


### PR DESCRIPTION
### Objetivo
- Fazer com que a prop `fonte` aceite html
- Fazer com que o texto do componente ocupe 100% de sua largura quando a prop `link` não é passada

Fix https://github.com/ImpulsoGov/design-system/issues/68