### PR TITLE
Adiciona botão auxiliar no ModalLogged

### DIFF
--- a/componentes/ModalLogged/ModalLogged.jsx
+++ b/componentes/ModalLogged/ModalLogged.jsx
@@ -26,7 +26,7 @@ const ModalLogged = (props)=>{
 
             {props.botaoAuxiliar &&
                 <button
-                    className={cx(style.Button, style.ButtonAuxiliar)}
+                    className={cx(style.Button, style.MargemComButtonAuxiliar)}
                     onClick={props.botaoAuxiliar.handelClick}
                 >
                     {props.botaoAuxiliar.label}
@@ -36,7 +36,7 @@ const ModalLogged = (props)=>{
             <button
                 className={cx(
                     style.Button,
-                    props.botaoAuxiliar ? style.ButtonAuxiliar : style.ButtonLogOut
+                    props.botaoAuxiliar ? style.MargemComButtonAuxiliar : style.MargemSemButtonAuxiliar
                 )}
                 onClick={()=>props.logout()}
             >SAIR</button>

--- a/componentes/ModalLogged/ModalLogged.jsx
+++ b/componentes/ModalLogged/ModalLogged.jsx
@@ -1,5 +1,7 @@
 import React from "react";
-import style from "./ModalLogged.module.css"
+import style from "./ModalLogged.module.css";
+import PropTypes from "prop-types";
+import cx from "classnames";
 
 const UserAvatar = (props)=>{
     return(
@@ -21,12 +23,36 @@ const ModalLogged = (props)=>{
                 cargo = {props.cargo}
                 equipe = {props.equipe}
             />
+
+            {props.botaoAuxiliar &&
+                <button
+                    className={cx(style.Button, style.ButtonAuxiliar)}
+                    onClick={props.botaoAuxiliar.handelClick}
+                >
+                    {props.botaoAuxiliar.label}
+                </button>
+            }
+
             <button
-                className={style.ButtonLogOut}
+                className={cx(
+                    style.Button,
+                    props.botaoAuxiliar ? style.ButtonAuxiliar : style.ButtonLogOut
+                )}
                 onClick={()=>props.logout()}
             >SAIR</button>
         </div>
     )
+}
+
+ModalLogged.defaultProps = {
+    botaoAuxiliar: null
+}
+
+ModalLogged.propTypes = {
+    botaoAuxiliar: PropTypes.shape({
+        label: PropTypes.string,
+        handelClick: PropTypes.func,
+    })
 }
 
 export {ModalLogged,UserAvatar}

--- a/componentes/ModalLogged/ModalLogged.module.css
+++ b/componentes/ModalLogged/ModalLogged.module.css
@@ -67,10 +67,10 @@
     cursor: pointer;
 }
 
-.ButtonLogOut{
+.MargemSemButtonAuxiliar{
     margin-top: 200px;
 }
 
-.ButtonAuxiliar {
+.MargemComButtonAuxiliar {
     margin-top: 100px;
 }

--- a/componentes/ModalLogged/ModalLogged.module.css
+++ b/componentes/ModalLogged/ModalLogged.module.css
@@ -42,8 +42,7 @@
 }
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@40;500&display=swap");
 
-.ButtonLogOut{
-    margin-top: 200px;
+.Button {
     border: 1px solid rgba(96, 110, 120, 0.15);
     background-color: #fff;
     color: #1F1F1F;
@@ -62,8 +61,16 @@
     text-decoration: none;
 }
 
-.ButtonLogOut:hover{
+.Button:hover{
     border: 1px solid rgba(96, 110, 120, 0.50);
     background-color: #fff;
     cursor: pointer;
+}
+
+.ButtonLogOut{
+    margin-top: 200px;
+}
+
+.ButtonAuxiliar {
+    margin-top: 100px;
 }

--- a/componentes/ModalLogged/ModalLogged.stories.js
+++ b/componentes/ModalLogged/ModalLogged.stories.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import { ModalLogged } from './index'
+import React from 'react';
+import { ModalLogged } from './index';
 
 export default {
     title: "Componentes/ModalLogged",
@@ -29,9 +29,19 @@ export default {
             name:'logout',
             description:'Função para logout do usuário *function*'
         },
+        botaoAuxiliar: {
+            name: 'botaoAuxiliar',
+            description: 'Objeto opcional com as propriedades do botão auxiliar do modal *object* \n\n **- label:** rótulo do botão auxiliar *string* \n\n **- handelClick:** função executado quando o botão auxiliar é clicado *function*',
+        }
     },
 };
-const sout = ()=> console.log("logout")
+
+const sout = ()=> console.log("logout");
+const botaoAuxiliar = {
+    label: "GESTÃO DE USUÁRIOS",
+    handelClick: () => console.log("Click botão auxiliar")
+};
+
 const Template = (args) => <ModalLogged {...args}/>
 export const Default = Template.bind({});
 Default.args={
@@ -40,5 +50,16 @@ Default.args={
     cargo : "Coordenadora APS",
     equipe : "00003287",
     button : {label:"sair",link:""},
-    logout : sout
-}
+    logout : sout,
+};
+
+export const ComBotaoAuxiliar = Template.bind({});
+ComBotaoAuxiliar.args={
+    nome : "Camila Alves",
+    label : "C",
+    cargo : "Coordenadora APS",
+    equipe : "00003287",
+    button : {label:"sair",link:""},
+    logout : sout,
+    botaoAuxiliar
+};

--- a/componentes/NavBar/NavBar.jsx
+++ b/componentes/NavBar/NavBar.jsx
@@ -126,6 +126,7 @@ const NavBar = (props) => {
                   button = {props?.user?.button}
                   logout = {props?.user?.logout}
                   equipe = {props?.user?.equipe}
+                  botaoAuxiliar = {props?.user?.botaoAuxiliar}
                 />
   const login = <Login
                   titulo = {props.login.titulo}

--- a/componentes/NavBar/NavBar.stories.js
+++ b/componentes/NavBar/NavBar.stories.js
@@ -8,7 +8,7 @@ export default {
     argTypes: {
         user: {
             name: "Dados do Usuário",
-            description: "Dados do usuário autenticado, utilizado pelo modal.\n\n**nome** : nome do usuário *string*,\n\n**cargo**: Cargo do usuário *string*,\n\n**button**: Rótulo do botão de sair *object*,\n\n**label**: Letra do botão de usuário quando autenticado *string*, \n\n**equipe**: Código INE *string*,\n\n**login**: Função de login *function*,\n\n**logout**: Função de logout *function* "
+            description: "Dados do usuário autenticado, utilizado pelo modal.\n\n**nome** : nome do usuário *string*,\n\n**cargo**: Cargo do usuário *string*,\n\n**button**: Rótulo do botão de sair *object*,\n\n**label**: Letra do botão de usuário quando autenticado *string*, \n\n**equipe**: Código INE *string*,\n\n**login**: Função de login *function*,\n\n**logout**: Função de logout *function* \n\n **botaoAuxiliar**: Objeto opcional com as propriedades do botão auxiliar do modal logado *object*"
         },
         login: {
             name: "Área de login",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@impulsogov/design-system",
-  "version": "1.0.169",
+  "version": "1.0.170",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@impulsogov/design-system",
-      "version": "1.0.169",
+      "version": "1.0.170",
       "dependencies": {
         "@babel/cli": "^7.18.9",
         "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@impulsogov/design-system",
   "description": "Impulso Gov Design System",
-  "version": "1.0.169",
+  "version": "1.0.170",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [


### PR DESCRIPTION
### Descrição
Com a necessidade de adicionar um link na área logada do site Impulso Previne que leva à página de gestão de usuários, surgiu a demanda de adicionar um segundo botão no `ModalLogged`, uma vez que adicionar esse link direto na `NavBar` ocuparia um espaço que poderia ser mais importante para outro fim.

### Objetivos
- Adicionar um botão auxiliar opcional no `ModalLogged`
- Permitir que a `NavBar` receba as props do novo botão auxiliar e passe elas para o `ModalLogged`

### Checklist de validação
- [ ] O botão auxiliar não é exibido no `ModalLogged` quando a prop `botaoAuxiliar` não é passada
- [ ] O botão auxiliar é exibido no `ModalLogged` quando a prop `botaoAuxiliar` é passada