### PR TITLE
Fecha ModalLogged após click no botão auxiliar

### DIFF
--- a/componentes/ModalLogged/ModalLogged.jsx
+++ b/componentes/ModalLogged/ModalLogged.jsx
@@ -27,7 +27,10 @@ const ModalLogged = (props)=>{
             {props.botaoAuxiliar &&
                 <button
                     className={cx(style.Button, style.MargemComButtonAuxiliar)}
-                    onClick={props.botaoAuxiliar.handelClick}
+                    onClick={ () => {
+                        props.botaoAuxiliar.handelClick()
+                        props.setModal(false)
+                    }}
                 >
                     {props.botaoAuxiliar.label}
                 </button>

--- a/componentes/NavBar/NavBar.jsx
+++ b/componentes/NavBar/NavBar.jsx
@@ -127,6 +127,7 @@ const NavBar = (props) => {
                   logout = {props?.user?.logout}
                   equipe = {props?.user?.equipe}
                   botaoAuxiliar = {props?.user?.botaoAuxiliar}
+                  setModal = {setModal}
                 />
   const login = <Login
                   titulo = {props.login.titulo}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@impulsogov/design-system",
-  "version": "1.0.173",
+  "version": "1.0.174",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@impulsogov/design-system",
-      "version": "1.0.173",
+      "version": "1.0.174",
       "dependencies": {
         "@babel/cli": "^7.18.9",
         "@babel/core": "^7.18.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@impulsogov/design-system",
-  "version": "1.0.172",
+  "version": "1.0.173",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@impulsogov/design-system",
-      "version": "1.0.172",
+      "version": "1.0.173",
       "dependencies": {
         "@babel/cli": "^7.18.9",
         "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@impulsogov/design-system",
   "description": "Impulso Gov Design System",
-  "version": "1.0.172",
+  "version": "1.0.173",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@impulsogov/design-system",
   "description": "Impulso Gov Design System",
-  "version": "1.0.173",
+  "version": "1.0.174",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [


### PR DESCRIPTION
### Descrição
Ao clicar no botão auxiliar no `ModalLogged`, o modal não fechava automaticamente, dando a impressão de que a página não atualizava.

### Objetivo
- Fechar o modal após clicar no botão auxiliar

### Checklist de validação
- [ ] O modal é fechado após clicar no botão auxiliar do `ModalLogged`