### PR TITLE
[Painel Busca Ativa] Corrige interação de filtro e ordenação

### DIFF
--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -29,6 +29,39 @@ const stringToDate = (str)=>{
     if(str.includes('/')) return dataFormatoBarra(str) 
     if(str.includes('-')) return dataFormatoTraco(str) 
 }
+
+const sortByDate = (data, filtro, IDFiltrosOrdenacao)=>{
+    return [...data].sort((a,b) =>{
+        const valueA = stringToDate(a[filtro])
+        const valueB = stringToDate(b[filtro])
+        if (valueA === null && valueB === null) {
+        return 0;
+        } else if (valueA === null) {
+        return 1;
+        } else if (valueB === null) {
+        return -1;
+        }
+        if(IDFiltrosOrdenacao[filtro] == "asc") return valueA - valueB
+        if(IDFiltrosOrdenacao[filtro] == "desc") return valueB - valueA
+    }
+)}
+
+const sortInt = (data, filtro, IDFiltrosOrdenacao)=>[...data].sort((a,b) => IDFiltrosOrdenacao[filtro] == "desc" ? Number(b[filtro]) - Number(a[filtro]) : Number(a[filtro]) - Number(b[filtro]))
+
+const sortByString = (data, filtro)=>[...data].sort((a,b) => a[filtro]?.toString().localeCompare(b[filtro]?.toString()) )
+
+const sortByChoice = (data, filtro, IDFiltrosOrdenacao, datefiltros, IntFiltros) => {
+    if (datefiltros.includes(filtro)) {
+        return sortByDate(data, filtro, IDFiltrosOrdenacao);
+    }
+
+    if (IntFiltros?.includes(filtro)) {
+        return sortInt(data, filtro, IDFiltrosOrdenacao);
+    }
+
+    return sortByString(data, filtro);
+}
+
 const SortData = ({
     data,
     setData,
@@ -43,29 +76,8 @@ const SortData = ({
     aba,
     sub_aba
 })=>{
-    const sortByDate = (data)=>{
-        return [...data].sort((a,b) =>{ 
-            const valueA = stringToDate(a[filtro]) 
-            const valueB = stringToDate(b[filtro])
-            if (valueA === null && valueB === null) {
-            return 0;
-            } else if (valueA === null) {
-            return 1;
-            } else if (valueB === null) {
-            return -1;
-            }
-            if(IDFiltrosOrdenacao[filtro] == "asc") return valueA - valueB 
-            if(IDFiltrosOrdenacao[filtro] == "desc") return valueB - valueA  
-        }
-    )}
-    const sortInt = (data)=>[...data].sort((a,b) => IDFiltrosOrdenacao[filtro] == "desc" ? Number(b[filtro]) - Number(a[filtro]) : Number(a[filtro]) - Number(b[filtro]))
-    const sortByString = (data)=>[...data].sort((a,b) => a[filtro]?.toString().localeCompare(b[filtro]?.toString()) )
-    datefiltros.includes(filtro) ? 
-    setData(sortByDate(data)) :
-    IntFiltros?.includes(filtro) ?
-    setData(sortInt(data)) :
-    setData(sortByString(data))
-    
+    setData(sortByChoice(data, filtro, IDFiltrosOrdenacao, datefiltros, IntFiltros))
+
     trackObject.track('button_click', {
         'button_action': 'aplicar_ordenacao',
         'nome_lista_nominal': painel,

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -88,23 +88,23 @@ const SortData = ({
     setModal(false)
     setOrdenacaoAplicada(true)
 }
-const FilterData = (props)=>{
-    const filtros = ValuesToChavesFiltros(props.value,props.setChavesFiltros,props.dadosFiltros)
-    const agruparChavesIguais =(filtros)=>{
-        const chavesUnicas = [...new Set(filtros.flatMap(objeto => Object.keys(objeto)))];
-        return chavesUnicas.map(chave => {
-            const objetosComChave = filtros.filter(objeto => objeto.hasOwnProperty(chave));
-            const valores = objetosComChave.map(objeto => objeto[chave]);
-            return { [chave]: valores };
-        });
-    }
-    const filtrosAgrupados = agruparChavesIguais(filtros)
-    const dadosFiltrados = props.data.filter(item => {
-        return filtrosAgrupados.every(filter =>{
+
+const agruparChavesIguais =(filtros)=>{
+    const chavesUnicas = [...new Set(filtros.flatMap(objeto => Object.keys(objeto)))];
+    return chavesUnicas.map(chave => {
+        const objetosComChave = filtros.filter(objeto => objeto.hasOwnProperty(chave));
+        const valores = objetosComChave.map(objeto => objeto[chave]);
+        return { [chave]: valores };
+    });
+}
+
+const filterByChoices = (data, filterChoices) => {
+    return data.filter(item => {
+        return filterChoices.every(filter =>{
             return filter["consultas_pre_natal_validas"] ? true : filter[Object.keys(filter)[0]].includes(item[Object.keys(filter)[0]].toString()) 
         });
     }).filter(item=>{
-        const filtroConsultas = filtrosAgrupados.filter(item=>item.hasOwnProperty('consultas_pre_natal_validas'))?.length > 0 ? filtrosAgrupados.filter(item=>item.hasOwnProperty('consultas_pre_natal_validas'))[0] : []
+        const filtroConsultas = filterChoices.filter(item=>item.hasOwnProperty('consultas_pre_natal_validas'))?.length > 0 ? filterChoices.filter(item=>item.hasOwnProperty('consultas_pre_natal_validas'))[0] : []
         if(filtroConsultas["consultas_pre_natal_validas"]?.length > 0){
             if(filtroConsultas["consultas_pre_natal_validas"]=='Maior ou igual a 6' && Number(item["consultas_pre_natal_validas"]) >= 6) return true
             if(filtroConsultas["consultas_pre_natal_validas"]=='Menor que 6' && Number(item["consultas_pre_natal_validas"]) < 6) return true
@@ -112,6 +112,12 @@ const FilterData = (props)=>{
         }
         return true
     })
+}
+
+const FilterData = (props)=>{
+    const filtros = ValuesToChavesFiltros(props.value,props.setChavesFiltros,props.dadosFiltros)
+    const filtrosAgrupados = agruparChavesIguais(filtros)
+    const dadosFiltrados = filterByChoices(props.data, filtrosAgrupados)
     const dadosOrdenados = sortByChoice(dadosFiltrados, props.ordenar, props.IDFiltrosOrdenacao, props.datefiltros, props.IntFiltros)
 
     props.setData(dadosOrdenados)

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -99,7 +99,7 @@ const FilterData = (props)=>{
         });
     }
     const filtrosAgrupados = agruparChavesIguais(filtros)
-    props.setData(props.data.filter(item => {
+    const dadosFiltrados = props.data.filter(item => {
         return filtrosAgrupados.every(filter =>{
             return filter["consultas_pre_natal_validas"] ? true : filter[Object.keys(filter)[0]].includes(item[Object.keys(filter)[0]].toString()) 
         });
@@ -111,7 +111,10 @@ const FilterData = (props)=>{
             return false
         }
         return true
-    }))
+    })
+    const dadosOrdenados = sortByChoice(dadosFiltrados, props.ordenar, props.IDFiltrosOrdenacao, props.datefiltros, props.IntFiltros)
+
+    props.setData(dadosOrdenados)
 
     props.trackObject.track('button_click', {
         'button_action': 'aplicar_filtro',
@@ -120,9 +123,6 @@ const FilterData = (props)=>{
         'sub_aba_lista_nominal' : props.sub_aba,
         'button_choices' : filtrosAgrupados
     });
-
-    props.setOrdenar()
-    props.setOrdenacaoAplicada(false)
 
     props.setModal(false)
 }
@@ -311,13 +311,16 @@ const Filtro = ({
     aba,
     sub_aba,
     setOrdenar,
-    setOrdenacaoAplicada
+    setOrdenacaoAplicada,
+    ordenar,
+    datefiltros,
+    IntFiltros,
+    IDFiltrosOrdenacao,
 })=>{
     const LimparFiltros = ()=>{
-        setData(tabela)
+        setData(sortByChoice(tabela, ordenar, IDFiltrosOrdenacao, datefiltros, IntFiltros))
         setChavesFiltros([])
         setModal(false)
-        
     }
     return(
         <div className={style.Filtro}>
@@ -356,7 +359,11 @@ const Filtro = ({
                         aba : aba,
                         sub_aba : sub_aba,
                         setOrdenar,
-                        setOrdenacaoAplicada                    
+                        setOrdenacaoAplicada,
+                        ordenar,
+                        datefiltros,
+                        IntFiltros,
+                        IDFiltrosOrdenacao,
                     }}
                 />  
             </div>
@@ -509,6 +516,10 @@ const PainelBuscaAtiva = ({
                                 sub_aba={sub_aba}
                                 setOrdenar={setOrdenar} 
                                 setOrdenacaoAplicada={setOrdenacaoAplicada}
+                                ordenar={ordenar} 
+                                datefiltros={datefiltros}
+                                IntFiltros={IntFiltros}
+                                IDFiltrosOrdenacao={IDFiltrosOrdenacao}
                             />
                         }
                     </Modal>

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -216,8 +216,17 @@ const Ordenar = (props)=>{
         "ID" : props.IDFiltros
     }
     const limpar = ()=>{
+        let dados = props.tabela
+        const temFiltrosAplicados = Object.values(props.filtros).some((filtro) => filtro);
+
+        if (temFiltrosAplicados) {
+            const filtrosEscolhidos = ValuesToChavesFiltros(props.filtros, props.setChavesFiltros, props.dadosFiltros)
+            const filtrosAgrupados = agruparChavesIguais(filtrosEscolhidos)
+            dados = filterByChoices(props.tabela, filtrosAgrupados)
+        }
+
         props.setOrdenar()
-        props.setData(props.tabela)
+        props.setData(dados)
         props.setModal(false)
         props.setOrdenacaoAplicada(false)
     }
@@ -503,6 +512,9 @@ const PainelBuscaAtiva = ({
                                 trackObject={trackObject}
                                 aba={aba}
                                 sub_aba={sub_aba}
+                                filtros={value}
+                                setChavesFiltros={setChavesFiltros}
+                                dadosFiltros={dadosFiltros}
                             />
                         }
                         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@impulsogov/design-system",
-  "version": "1.0.176",
+  "version": "1.0.177",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@impulsogov/design-system",
-      "version": "1.0.176",
+      "version": "1.0.177",
       "dependencies": {
         "@babel/cli": "^7.18.9",
         "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@impulsogov/design-system",
   "description": "Impulso Gov Design System",
-  "version": "1.0.176",
+  "version": "1.0.177",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [


### PR DESCRIPTION
### Descrição
Ao usar o Painel de busca ativa, notou-se que a tabela perdia a ordenação aplicada, caso tivesse, após aplicar filtros. Além disso, após limpar a ordenação com filtros já aplicados, a filtragem dos dados era perdida na tabela, mas o componente de filtro ainda mostrava que os filtros estavam aplicados. Logo, é necessário corrigir essa interação entre filtro e ordenação.

### Objetivos
- Manter a ordenação escolhida pelo usuário após filtrar os dados ou limpar os filtros
- Manter os filtros já aplicados pelo usuários após limpar a ordenação

### Checklist de validação
- [ ] A ordenação aplicada se mantém após filtrar os dados da tabela
- [ ] A ordenação aplicada se mantém após limpar os filtros da tabela
- [ ] Os filtros aplicados se mantém após ordenar a tabela
- [ ] Os filtros aplicados se mantém após limpar a ordenação da tabela