### PR TITLE
Adiciona prop fontFamily nas tabelas de impressão

### DIFF
--- a/componentes/TabelaGestantes/TabelaGestantes.jsx
+++ b/componentes/TabelaGestantes/TabelaGestantes.jsx
@@ -83,7 +83,7 @@ const identificacao_atendimento_odontologico = [
 ]
 const atendimento_odontologico = (str)=>identificacao_atendimento_odontologico.find(item=>item.id_atendimento_odontologico==str).atendimento_odontologico_descricao
 
-const TabelaGestantesImpressao = ({ data,colunas}) => {
+const TabelaGestantesImpressao = ({ data, colunas, fontFamily = "Inter"}) => {
   return (
     <table style={{
       borderCollapse: "collapse",
@@ -91,7 +91,7 @@ const TabelaGestantesImpressao = ({ data,colunas}) => {
       color:  "#1F1F1F",
       textAlign: "center",
       fontSize: "12px",
-      fontFamily: "Inter",
+      fontFamily,
       letterSpacing: "-0.12px",
       textTransform: "uppercase",
     }}>

--- a/componentes/TabelaHiperDia/TabelaHiperDia.jsx
+++ b/componentes/TabelaHiperDia/TabelaHiperDia.jsx
@@ -182,7 +182,7 @@ const prazoStyle = (value)=>{
 
 }
 
-const TabelaHiperDiaImpressao = ({ data,colunas }) => {
+const TabelaHiperDiaImpressao = ({ data, colunas, fontFamily = "Inter" }) => {
     return (
       <table style={{
         borderCollapse: "collapse",
@@ -190,7 +190,7 @@ const TabelaHiperDiaImpressao = ({ data,colunas }) => {
         color:  "#1F1F1F",
         textAlign: "center",
         fontSize: "12px",
-        fontFamily: "Inter",
+        fontFamily,
         letterSpacing: "-0.12px",
         textTransform: "uppercase",
       }}>
@@ -371,7 +371,7 @@ const selecionar_status_usuario_descricao = (value,status_usuario_descricao)=> {
       </div>
   }
 
-  const TabelaCitoImpressao = ({ data,colunas,status_usuario_descricao}) => {
+  const TabelaCitoImpressao = ({ data, colunas, status_usuario_descricao, fontFamily = "Inter"}) => {
     return (
       <table style={{
         borderCollapse: "collapse",
@@ -379,7 +379,7 @@ const selecionar_status_usuario_descricao = (value,status_usuario_descricao)=> {
         color:  "#1F1F1F",
         textAlign: "center",
         fontSize: "12px",
-        fontFamily: "Inter",
+        fontFamily,
         letterSpacing: "-0.12px",
         textTransform: "uppercase",
       }}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@impulsogov/design-system",
-  "version": "1.0.175",
+  "version": "1.0.176",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@impulsogov/design-system",
-      "version": "1.0.175",
+      "version": "1.0.176",
       "dependencies": {
         "@babel/cli": "^7.18.9",
         "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@impulsogov/design-system",
   "description": "Impulso Gov Design System",
-  "version": "1.0.175",
+  "version": "1.0.176",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [


### PR DESCRIPTION
### Descrição
- Permite alteração da fonte usada nas tabelas de impressão, similar a https://github.com/ImpulsoGov/design-system/pull/165

### Objetivos
- Receber a fonte usada nas tabelas de hiperdia, citopatológico e gestantes como prop

### Checklist de validação
- [ ] É possível mudar a fonte da tabela a partir da prop `fontFamily` nas tabelas `TabelaHiperDiaImpressao`, `TabelaCitoImpressao` e `TabelaGestantesImpressao`