### PR TITLE
[Painel busca ativa] Checa se valor do dado filtrado é truthy antes de converter para string

### DIFF
--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -101,7 +101,8 @@ const agruparChavesIguais =(filtros)=>{
 const filterByChoices = (data, filterChoices) => {
     return data.filter(item => {
         return filterChoices.every(filter =>{
-            return filter["consultas_pre_natal_validas"] ? true : filter[Object.keys(filter)[0]].includes(item[Object.keys(filter)[0]].toString()) 
+            if (!item[Object.keys(filter)[0]]) return false
+            return filter["consultas_pre_natal_validas"] ? true : filter[Object.keys(filter)[0]].includes(item[Object.keys(filter)[0]].toString())
         });
     }).filter(item=>{
         const filtroConsultas = filterChoices.filter(item=>item.hasOwnProperty('consultas_pre_natal_validas'))?.length > 0 ? filterChoices.filter(item=>item.hasOwnProperty('consultas_pre_natal_validas'))[0] : []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@impulsogov/design-system",
-  "version": "1.0.177",
+  "version": "1.0.178",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@impulsogov/design-system",
-      "version": "1.0.177",
+      "version": "1.0.178",
       "dependencies": {
         "@babel/cli": "^7.18.9",
         "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@impulsogov/design-system",
   "description": "Impulso Gov Design System",
-  "version": "1.0.177",
+  "version": "1.0.178",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [


### PR DESCRIPTION
### Descrição
Hoje foi evidenciado que, para alguns municípios, o botão de aplicar filtro, no modal do painel de busca ativa, não estava respondendo, como detalhado [aqui](https://impulsogov.slack.com/archives/C04G8VCAC2G/p1709039865837769).

Quando tentei filtrar os dados do painel por nome do Profissional Responsável, surgiu o seguinte erro no console do navegador:

![image](https://github.com/ImpulsoGov/design-system/assets/45800622/c9d65314-97ee-40fd-a8ad-7b556e911d43)

Tentei aplicar outros filtros e notei que essa mensagem de erro só aparecia quando alguma opção de filtro por nome do Profissional Responsável estava selecionada. Os outros filtros funcionavam normalmente quando o filtro por nome de profissional não estava aplicado.

Investigando mais o problema, entendi que o erro ocorria sempre que a propriedade escolhida para filtro possuía esse campo com valor nulo nos dados da tabela, fosse o filtro escolhido por nome de profissional ou outro. Então, ao acessar o método `toString()` de um valor nulo, dentro da função `filterByChoices`, o erro era levantado e os dados não eram filtrados.

### Objetivos
- Checar se a propriedade escolhida para filtro possui esse campo com valor nulo antes de acessar o método `toString()`

### Checklist de validação
- [ ] O filtro por nome do ACS funciona corretamente no Painel de busca ativa cito na [preview](https://design-system-git-fix-filtro-painel-busca-ativa-impulso-gov.vercel.app/) (esse painel possui um dos dados com o campo `acs_nome: null` e, por isso, acontecia o mesmo comportamento evidenciado hoje na thread do slack)