### PR TITLE
[Quick wins] Fechar filtro da lista nominal quando outro é expandido

### DIFF
--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -308,9 +308,21 @@ const FiltroBody = ({
     trackObject,
     painel,
     aba,
-    sub_aba
+    sub_aba,
+    isUnfolded = false,
+    onClick = () => {},
 })=>{
     const [show,setShow] = useState(false)
+
+    useEffect(() => {
+        setShow(isUnfolded);
+    }, [isUnfolded])
+
+    function handleClick() {
+        setShow((prevState) => !prevState);
+        onClick(data.rotulo);
+    }
+
     return(
         <>
             <div className={style.ConteinerFiltro}>
@@ -318,7 +330,7 @@ const FiltroBody = ({
                     <p>{data.rotulo}</p>
                     <button
                         className={style.ShowFiltros}
-                        onClick={()=>setShow(!show)}
+                        onClick={handleClick}
                     >
                         {show ? "-" : "+"}
                     </button>
@@ -341,7 +353,6 @@ const FiltroBody = ({
                                         painel={painel}
                                         aba={aba}
                                         sub_aba={sub_aba}
-        
                                     />
                                 )
                             })
@@ -374,6 +385,12 @@ const Filtro = ({
     IDFiltrosOrdenacao,
     setShowSnackBar,
 })=>{
+    const [unfoldedFilter, setUnfoldedFilter] = useState('')
+
+    function updateUnfoldedFilter(filterName) {
+        setUnfoldedFilter(filterName);
+    }
+
     const LimparFiltros = ()=>{
         setData(sortByChoice(tabela, ordenar, IDFiltrosOrdenacao, datefiltros, IntFiltros))
         setChavesFiltros([])
@@ -394,7 +411,8 @@ const Filtro = ({
                         painel={painel}
                         aba={aba}
                         sub_aba={sub_aba}
-
+                        isUnfolded={unfoldedFilter === filtro.rotulo}
+                        onClick={updateUnfoldedFilter}
                     />)
                 }
             </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@impulsogov/design-system",
-  "version": "1.0.209",
+  "version": "1.0.210",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@impulsogov/design-system",
-      "version": "1.0.209",
+      "version": "1.0.210",
       "dependencies": {
         "@babel/cli": "^7.18.9",
         "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@impulsogov/design-system",
   "description": "Impulso Gov Design System",
-  "version": "1.0.209",
+  "version": "1.0.210",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [


### PR DESCRIPTION
### Contexto
Detalhamento das quick wins feitas:
- [Fechar filtro quando outro é expandido](https://www.notion.so/impulsogov/Incluir-comportamento-de-comprimir-lista-de-filtros-quando-uma-nova-expandida-427409c722874bd9943a972ed16d03f2?pvs=4)

### Objetivos
- Adicionar comportamento de fechar opções de um filtro quando outro é expandido no FiltroBody

### Checklist de validação
- Fechar filtro quando outro é expandido
  - [ ] Ao expandir um filtro clicando em `+` e fechá-lo clicando em `-`, o filtro é fechado normalmente
  - [ ] Ao expandir um filtro e em seguida expandir outro, o primeiro filtro deve ser fechado automaticamente