### PR TITLE
Remove evento de alerta de digitação de caracteres não numéricos no login

### DIFF
--- a/componentes/Login/Login.jsx
+++ b/componentes/Login/Login.jsx
@@ -24,12 +24,6 @@ const Login = (props)=>{
             // Procura todos os caracteres não numericos
             let naoNumeros = value.match(/[^\d.-]/g)
             setAlertCPF(naoNumeros ? true : false)
-            if (props.trackObject) {
-                props.trackObject.track('validation_error', {
-                    'button_action': 'digitou_caractere_nao_numerico',
-                    'error_message' : "Agora não utilizamos mais e-mail para login. Você deve utilizar seu CPF e senha cadastrada."
-                });
-            }
             // Remove qualquer caractere que não seja um dígito numerico
             value = value.replace(/\D/g, '');
             // Se o valor tem mais de 3 dígitos, adicione um ponto após os primeiros 3 dígitos

--- a/componentes/PainelBuscaAtiva/tippy_theme.css
+++ b/componentes/PainelBuscaAtiva/tippy_theme.css
@@ -4,6 +4,6 @@
     font-style: normal;
     font-weight: 400;
     text-align: center;
-    background-color: #FFF0E1;
+    background-color: #FFF7DE;
     color: #1F1F1F;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@impulsogov/design-system",
-  "version": "1.0.207",
+  "version": "1.0.208",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@impulsogov/design-system",
-      "version": "1.0.207",
+      "version": "1.0.208",
       "dependencies": {
         "@babel/cli": "^7.18.9",
         "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@impulsogov/design-system",
   "description": "Impulso Gov Design System",
-  "version": "1.0.207",
+  "version": "1.0.208",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [


### PR DESCRIPTION
### Contexto
- Considerando o alto numero de disparos realizados pelo evento de digitação de caracteres não numéricos no login, conforme indicado nessa [thread](https://impulsogov.slack.com/archives/C05FNRDAJDA/p1714494461602409?thread_ts=1714494333.394589&cid=C05FNRDAJDA), se tornou muito alto para o plano contratado no mixpanel, sendo assim os times de analise e produto decidiram remover esse evento.

### Objetivos
- Remover o evento

### Checklist de validação
  - [ ] Evento não é disparado para mixpanel