### PR TITLE
[PanelSelector] Remove padding e renomeia prop

### DIFF
--- a/componentes/PanelSelector/PanelSelector.jsx
+++ b/componentes/PanelSelector/PanelSelector.jsx
@@ -10,7 +10,7 @@ const PanelSelector = ({
   links,
   components,
   states,
-  breakTitlesLine = false,
+  breakLines = false,
 }) => {
   const [distanciaSubAba,setDistanciaSubAba] = useState(0)
   const titleRefs = titles.map(() => useRef(null));
@@ -44,7 +44,7 @@ const PanelSelector = ({
   }, [titleRefs, states.activeTitleTabIndex]);
   return (
     <div style={{zIndex:90,width:'100%'}}>
-      <div className={cx(style.PanelSelectorMain, breakTitlesLine && style.PanelSelectorMainLineBreak)}>
+      <div className={cx(style.PanelSelectorMain, breakLines && style.PanelSelectorMainLineBreak)}>
         <div className={style.PanelSelectorTitles}>
           {titles.map((item, index) => (
             <div
@@ -57,7 +57,7 @@ const PanelSelector = ({
                 states.activeTitleTabIndex === index
                   ? style.PanelSelectorTitleButtonSelected
                   : style.PanelSelectorTitleButton,
-                breakTitlesLine && style.PanelSelectorTitleButtonLineBreak
+                breakLines && style.PanelSelectorTitleButtonLineBreak
               )}
             >
               {item.label}
@@ -68,7 +68,7 @@ const PanelSelector = ({
         <div
           className={cx(
             style.PanelSelectorContainerIP,
-            breakTitlesLine && style.PanelSelectorContainerIPLineBreak
+            breakLines && style.PanelSelectorContainerIPLineBreak
           )}
           style={PanelSelectorContainerPosition}
         >
@@ -82,7 +82,7 @@ const PanelSelector = ({
                 states.activeTabIndex === index
                   ? style.PanelSelectorButtonSelected
                   : style.PanelSelectorButton,
-                breakTitlesLine && style.PanelSelectorButtonLineBreak
+                breakLines && style.PanelSelectorButtonLineBreak
             )}
             >
               {item.label}

--- a/componentes/PanelSelector/PanelSelector.module.css
+++ b/componentes/PanelSelector/PanelSelector.module.css
@@ -200,6 +200,7 @@
     justify-content: center;
     width: min-content;
     min-width: 11%;
+    padding: 0px;
   }
 
   .PanelSelectorTitleButtonLineBreak {
@@ -207,6 +208,7 @@
     width: 21%;
     align-items: flex-end;
     white-space: normal;
+    padding: 0px;
   }
 
   .PanelSelectorMainLineBreak {

--- a/componentes/PanelSelector/PanelSelector.stories.js
+++ b/componentes/PanelSelector/PanelSelector.stories.js
@@ -259,9 +259,9 @@ export default {
             name:'components',
             description:'Componentes React a serem exibidos no painel *array/array* \n\n **children:** Componentes React *array*'
         },
-        breakTitlesLine:{
-            name:'breakTitlesLine',
-            description:'Define se é feita quebra de linha dos títulos das abas e subabas *boolean*'
+        breakLines:{
+            name:'breakLines',
+            description:'Define se é feita quebra de linha dos títulos das abas e subabas em telas com largura intermediária *boolean*'
         },
         states:{
             name:'states',
@@ -322,5 +322,5 @@ ComQuebraDeLinha.args={
   list: labelsPreNatal,
   titles: titlesPreNatal,
   initialTitle: 1,
-  breakTitlesLine: true
+  breakLines: true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@impulsogov/design-system",
-  "version": "1.0.208",
+  "version": "1.0.209",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@impulsogov/design-system",
-      "version": "1.0.208",
+      "version": "1.0.209",
       "dependencies": {
         "@babel/cli": "^7.18.9",
         "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@impulsogov/design-system",
   "description": "Impulso Gov Design System",
-  "version": "1.0.208",
+  "version": "1.0.209",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [


### PR DESCRIPTION
### Contexto
Conforme discutido [nessa thread](https://impulsogov.slack.com/archives/C05FNRDAJDA/p1714686702936089), a quebra de texto dos botões do seletor de painéis variava dependendo do botão estar selecionado ou não.

### Objetivos
- Remover padding aplicado ao selecionar os botões do painel quando a prop `breakLines` recebe valor `true` para evitar que a quebra de linha aplicada mude a depender de sua seleção
- Renomear prop que controla se os títulos do seletor devem ser quebrados em nova linha para `breakLines` para facilitar entendimento

### Checklist de validação
- [ ] Não há mais padding aplicado ao selecionar os botões do painel quando a prop `breakLines` tem valor `true`