### PR TITLE
[Testes] Corrige warning de uso do act

### DIFF
--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.test.js
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.test.js
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as responses from "./__data__";
 import { PainelBuscaAtiva } from ".";
@@ -94,8 +94,7 @@ describe(`Componente: ${COMPONENT}`, () => {
       const user = userEvent.setup();
       render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
-      const btnShowModal = screen.getByRole("button", { name: /ordenar lista/i });
-      await user.click(btnShowModal);
+      await act(async () => await user.click(screen.getByRole("button", { name: /ordenar lista/i })));
 
       expect(screen.getByTestId("Modal")).toBeInTheDocument();
       expect(screen.getByTestId("Ordenar")).toBeInTheDocument();
@@ -107,8 +106,7 @@ describe(`Componente: ${COMPONENT}`, () => {
       const user = userEvent.setup();
       render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
-      const btnShowModal = screen.getByRole("button", { name: /filtrar lista nominal/i });
-      await user.click(btnShowModal);
+      await act(async () => await user.click(screen.getByRole("button", { name: /filtrar lista nominal/i })));
 
       expect(screen.getByTestId("Modal")).toBeInTheDocument();
       expect(screen.getByTestId("Filtro")).toBeInTheDocument();
@@ -121,10 +119,10 @@ describe(`Componente: ${COMPONENT}`, () => {
       render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
       const btnShowModal = screen.getByRole("button", { name: /ordenar lista/i });
-      await user.click(btnShowModal);
+      await act(async () => await user.click(btnShowModal));
 
       const areaOutsideModal = screen.getByTestId("BlurArea");
-      await user.click(areaOutsideModal);
+      await act(async () => await user.click(areaOutsideModal));
 
       expect(screen.queryByTestId("Modal")).not.toBeInTheDocument();
     });
@@ -137,14 +135,14 @@ describe(`Componente: ${COMPONENT}`, () => {
         render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
         const btnShowModal = screen.getByRole("button", { name: /ordenar lista/i });
-        await user.click(btnShowModal);
+        await act(async () => await user.click(btnShowModal));
 
         const sortOption = screen.getByText(/nome do acs de a-z/i);
-        await user.click(sortOption);
+        await act(async () => await user.click(sortOption));
 
         const sortModal = screen.getByTestId("Ordenar");
         const btnApplySort = within(sortModal).getByRole("button", { name: /ordenar lista/i });
-        await user.click(btnApplySort);
+        await act(async () => await user.click(btnApplySort));
 
         const rows = screen.getAllByRole("row");
 
@@ -173,27 +171,27 @@ describe(`Componente: ${COMPONENT}`, () => {
           render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
           const btnShowSortModal = screen.getByRole("button", { name: /ordenar lista/i });
-          await user.click(btnShowSortModal);
+          await act(async () => await user.click(btnShowSortModal));
 
           const sortOption = screen.getByText(/vencimento da coleta mais antigo/i);
-          await user.click(sortOption);
+          await act(async () => await user.click(sortOption));
 
           const sortModal = screen.getByTestId("Ordenar");
           const btnApplySort = within(sortModal).getByRole("button", { name: /ordenar lista/i });
-          await user.click(btnApplySort);
+          await act(async () => await user.click(btnApplySort));
 
           const btnShowFilterModal = screen.getByRole("button", { name: /filtrar lista nominal/i });
-          await user.click(btnShowFilterModal);
+          await act(async () => await user.click(btnShowFilterModal));
 
           const [showFilterOptions] = screen.getAllByRole("button", { name: "+" });
-          await user.click(showFilterOptions);
+          await act(async () => await user.click(showFilterOptions));
 
           const filterOption = screen.getByLabelText(/alessandra santos/i);
-          await user.click(filterOption);
+          await act(async () => await user.click(filterOption));
 
           const filterModal = screen.getByTestId("Filtro");
           const btnApplyFilter = within(filterModal).getByRole("button", { name: /filtrar lista nominal/i });
-          await user.click(btnApplyFilter);
+          await act(async () => await user.click(btnApplyFilter));
 
           const rows = screen.getAllByRole("row");
 
@@ -223,19 +221,19 @@ describe(`Componente: ${COMPONENT}`, () => {
           render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
           const btnShowModal = screen.getByRole("button", { name: /ordenar lista/i });
-          await user.click(btnShowModal);
+          await act(async () => await user.click(btnShowModal));
 
           const sortOption = screen.getByText(/nome do acs de a-z/i);
-          await user.click(sortOption);
+          await act(async () => await user.click(sortOption));
 
           const sortModal = screen.getByTestId("Ordenar");
           const btnApplySort = within(sortModal).getByRole("button", { name: /ordenar lista/i });
-          await user.click(btnApplySort);
+          await act(async () => await user.click(btnApplySort));
 
-          await user.click(btnShowModal);
+          await act(async () => await user.click(btnShowModal));
 
           const clearSortOption = screen.getByText(/limpar ordenação/i);
-          await user.click(clearSortOption);
+          await act(async () => await user.click(clearSortOption));
 
           const rows = screen.getAllByRole("row");
 
@@ -254,32 +252,32 @@ describe(`Componente: ${COMPONENT}`, () => {
             render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
             const btnShowSortModal = screen.getByRole("button", { name: /ordenar lista/i });
-            await user.click(btnShowSortModal);
+            await act(async () => await user.click(btnShowSortModal));
 
             const sortOption = screen.getByText(/vencimento da coleta mais antigo/i);
-            await user.click(sortOption);
+            await act(async () => await user.click(sortOption));
 
             const sortModal = screen.getByTestId("Ordenar");
             const btnApplySort = within(sortModal).getByRole("button", { name: /ordenar lista/i });
-            await user.click(btnApplySort);
+            await act(async () => await user.click(btnApplySort));
 
             const btnShowFilterModal = screen.getByRole("button", { name: /filtrar lista nominal/i });
-            await user.click(btnShowFilterModal);
+            await act(async () => await user.click(btnShowFilterModal));
 
             const [showFilterOptions] = screen.getAllByRole("button", { name: "+" });
-            await user.click(showFilterOptions);
+            await act(async () => await user.click(showFilterOptions));
 
             const filterOption = screen.getByLabelText(/alessandra santos/i);
-            await user.click(filterOption);
+            await act(async () => await user.click(filterOption));
 
             const filterModal = screen.getByTestId("Filtro");
             const btnApplyFilter = within(filterModal).getByRole("button", { name: /filtrar lista nominal/i });
-            await user.click(btnApplyFilter);
+            await act(async () => await user.click(btnApplyFilter));
 
-            await user.click(btnShowSortModal);
+            await act(async () => await user.click(btnShowSortModal));
 
             const clearSortOption = screen.getByText(/limpar ordenação/i);
-            await user.click(clearSortOption);
+            await act(async () => await user.click(clearSortOption));
 
             const rows = screen.getAllByRole("row");
 
@@ -311,17 +309,17 @@ describe(`Componente: ${COMPONENT}`, () => {
         render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
         const btnShowModal = screen.getByRole("button", { name: /ordenar lista/i });
-        await user.click(btnShowModal);
+        await act(async () => await user.click(btnShowModal));
 
         const sortByAcsNameOption = screen.getByText(/nome do acs de a-z/i);
-        await user.click(sortByAcsNameOption);
+        await act(async () => await user.click(sortByAcsNameOption));
 
         const sortByAgeOption = screen.getByText(/idade do paciente/i);
-        await user.click(sortByAgeOption);
+        await act(async () => await user.click(sortByAgeOption));
 
         const sortModal = screen.getByTestId("Ordenar");
         const btnApplySort = within(sortModal).getByRole("button", { name: /ordenar lista/i });
-        await user.click(btnApplySort);
+        await act(async () => await user.click(btnApplySort));
 
         const rows = screen.getAllByRole("row");
 
@@ -352,17 +350,17 @@ describe(`Componente: ${COMPONENT}`, () => {
         render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
         const btnShowFilterModal = screen.getByRole("button", { name: /filtrar lista nominal/i });
-        await user.click(btnShowFilterModal);
+        await act(async () => await user.click(btnShowFilterModal));
 
         const [_, showFilterOptions] = screen.getAllByRole("button", { name: "+" });
-        await user.click(showFilterOptions);
+        await act(async () => await user.click(showFilterOptions));
 
         const filterOption = screen.getByLabelText(/Nunca realizou coleta/i);
-        await user.click(filterOption);
+        await act(async () => await user.click(filterOption));
 
         const filterModal = screen.getByTestId("Filtro");
         const btnApplyFilter = within(filterModal).getByRole("button", { name: /filtrar lista nominal/i });
-        await user.click(btnApplyFilter);
+        await act(async () => await user.click(btnApplyFilter));
 
         const rows = screen.getAllByRole("row");
 
@@ -380,27 +378,27 @@ describe(`Componente: ${COMPONENT}`, () => {
           render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
           const btnShowFilterModal = screen.getByRole("button", { name: /filtrar lista nominal/i });
-          await user.click(btnShowFilterModal);
+          await act(async () => await user.click(btnShowFilterModal));
 
           const [showFilterOptions] = screen.getAllByRole("button", { name: "+" });
-          await user.click(showFilterOptions);
+          await act(async () => await user.click(showFilterOptions));
 
           const filterOption = screen.getByLabelText(/alessandra santos/i);
-          await user.click(filterOption);
+          await act(async () => await user.click(filterOption));
 
           const filterModal = screen.getByTestId("Filtro");
           const btnApplyFilter = within(filterModal).getByRole("button", { name: /filtrar lista nominal/i });
-          await user.click(btnApplyFilter);
+          await act(async () => await user.click(btnApplyFilter));
 
           const btnShowSortModal = screen.getByRole("button", { name: /ordenar lista/i });
-          await user.click(btnShowSortModal);
+          await act(async () => await user.click(btnShowSortModal));
 
           const sortOption = screen.getByText(/idade do paciente/i);
-          await user.click(sortOption);
+          await act(async () => await user.click(sortOption));
 
           const sortModal = screen.getByTestId("Ordenar");
           const btnApplySort = within(sortModal).getByRole("button", { name: /ordenar lista/i });
-          await user.click(btnApplySort);
+          await act(async () => await user.click(btnApplySort));
 
           const rows = screen.getAllByRole("row");
 
@@ -426,22 +424,22 @@ describe(`Componente: ${COMPONENT}`, () => {
           render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
           const btnShowFilterModal = screen.getByRole("button", { name: /filtrar lista nominal/i });
-          await user.click(btnShowFilterModal);
+          await act(async () => await user.click(btnShowFilterModal));
 
           const [showFilterOptions] = screen.getAllByRole("button", { name: "+" });
-          await user.click(showFilterOptions);
+          await act(async () => await user.click(showFilterOptions));
 
           const filterOption = screen.getByLabelText(/alessandra santos/i);
-          await user.click(filterOption);
+          await act(async () => await user.click(filterOption));
 
           const filterModal = screen.getByTestId("Filtro");
           const btnApplyFilter = within(filterModal).getByRole("button", { name: /filtrar lista nominal/i });
-          await user.click(btnApplyFilter);
+          await act(async () => await user.click(btnApplyFilter));
 
-          await user.click(btnShowFilterModal);
+          await act(async () => await user.click(btnShowFilterModal));
 
           const clearFilterOption = screen.getByText(/limpar filtros/i);
-          await user.click(clearFilterOption);
+          await act(async () => await user.click(clearFilterOption));
 
           const rows = screen.getAllByRole("row");
 
@@ -460,32 +458,32 @@ describe(`Componente: ${COMPONENT}`, () => {
             render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
             const btnShowFilterModal = screen.getByRole("button", { name: /filtrar lista nominal/i });
-            await user.click(btnShowFilterModal);
+            await act(async () => await user.click(btnShowFilterModal)  );
 
             const [_, showFilterOptions] = screen.getAllByRole("button", { name: "+" });
-            await user.click(showFilterOptions);
+            await act(async () => await user.click(showFilterOptions)  );
 
             const filterOption = screen.getByLabelText(/coleta em dia/i);
-            await user.click(filterOption);
+            await act(async () => await user.click(filterOption)  );
 
             const filterModal = screen.getByTestId("Filtro");
             const btnApplyFilter = within(filterModal).getByRole("button", { name: /filtrar lista nominal/i });
-            await user.click(btnApplyFilter);
+            await act(async () => await user.click(btnApplyFilter)  );
 
             const btnShowSortModal = screen.getByRole("button", { name: /ordenar lista/i });
-            await user.click(btnShowSortModal);
+            await act(async () => await user.click(btnShowSortModal)  );
 
             const sortOption = screen.getByText(/vencimento da coleta mais antigo/i);
-            await user.click(sortOption);
+            await act(async () => await user.click(sortOption)  );
 
             const sortModal = screen.getByTestId("Ordenar");
             const btnApplySort = within(sortModal).getByRole("button", { name: /ordenar lista/i });
-            await user.click(btnApplySort);
+            await act(async () => await user.click(btnApplySort)  );
 
-            await user.click(btnShowFilterModal);
+            await act(async () => await user.click(btnShowFilterModal)  );
 
             const clearFilterOption = screen.getByText(/limpar filtros/i);
-            await user.click(clearFilterOption);
+            await act(async () => await user.click(clearFilterOption)  );
 
             const rows = screen.getAllByRole("row");
 
@@ -515,20 +513,20 @@ describe(`Componente: ${COMPONENT}`, () => {
           render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
           const btnShowFilterModal = screen.getByRole("button", { name: /filtrar lista nominal/i });
-          await user.click(btnShowFilterModal);
+          await act(async () => await user.click(btnShowFilterModal));
 
           const [showFilterOptions] = screen.getAllByRole("button", { name: "+" });
-          await user.click(showFilterOptions);
+          await act(async () => await user.click(showFilterOptions));
 
           const filterOption = screen.getByLabelText(/carmen miranda/i);
-          await user.click(filterOption);
+          await act(async () => await user.click(filterOption));
 
           const filterModal = screen.getByTestId("Filtro");
           const btnApplyFilter = within(filterModal).getByRole("button", { name: /filtrar lista nominal/i });
-          await user.click(btnApplyFilter);
+          await act(async () => await user.click(btnApplyFilter));
 
-          await user.click(btnShowFilterModal);
-          await user.click(screen.getAllByRole("button", { name: "+" })[0]);
+          await act(async () => await user.click(btnShowFilterModal));
+          await act(async () => await user.click(screen.getAllByRole("button", { name: "+" })[0]));
 
           expect(screen.getByLabelText(/carmen miranda/i)).toBeChecked();
         });
@@ -541,26 +539,26 @@ describe(`Componente: ${COMPONENT}`, () => {
         render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
         const btnShowFilterModal = screen.getByRole("button", { name: /filtrar lista nominal/i });
-        await user.click(btnShowFilterModal);
+        await act(async () => await user.click(btnShowFilterModal));
 
         const [showACSFilterOptions, showStatusFilterOptions] = screen.getAllByRole("button", { name: "+" });
 
-        await user.click(showStatusFilterOptions);
+        await act(async () => await user.click(showStatusFilterOptions));
 
         const filterOptionStatus = screen.getByLabelText(/coleta em dia/i);
-        await user.click(filterOptionStatus);
+        await act(async () => await user.click(filterOptionStatus));
 
         const hideStatusFilterOptions = screen.getByRole("button", { name: "-" });
-        await user.click(hideStatusFilterOptions);
+        await act(async () => await user.click(hideStatusFilterOptions));
 
-        await user.click(showACSFilterOptions);
+        await act(async () => await user.click(showACSFilterOptions));
 
         const filterOptionACS = screen.getByLabelText(/carmen miranda/i);
-        await user.click(filterOptionACS);
+        await act(async () => await user.click(filterOptionACS));
 
         const filterModal = screen.getByTestId("Filtro");
         const btnApplyFilter = within(filterModal).getByRole("button", { name: /filtrar lista nominal/i });
-        await user.click(btnApplyFilter);
+        await act(async () => await user.click(btnApplyFilter));
 
         const rows = screen.getAllByRole("row");
 
@@ -579,31 +577,30 @@ describe(`Componente: ${COMPONENT}`, () => {
           render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
           const btnShowFilterModal = screen.getByRole("button", { name: /filtrar lista nominal/i });
-          await user.click(btnShowFilterModal);
+          await act(async () => await user.click(btnShowFilterModal));
 
           const [showACSFilterOptions, showStatusFilterOptions] = screen.getAllByRole("button", { name: "+" });
-
-          await user.click(showStatusFilterOptions);
+          await act(async () => await user.click(showStatusFilterOptions));
 
           const filterOptionStatus = screen.getByLabelText(/nunca realizou coleta/i);
-          await user.click(filterOptionStatus);
+          await act(async () => await user.click(filterOptionStatus));
 
           const hideStatusFilterOptions = screen.getByRole("button", { name: "-" });
-          await user.click(hideStatusFilterOptions);
+          await act(async () => await user.click(hideStatusFilterOptions));
 
-          await user.click(showACSFilterOptions);
+          await act(async () => await user.click(showACSFilterOptions));
 
           const filterOptionACS = screen.getByLabelText(/alessandra santos/i);
-          await user.click(filterOptionACS);
+          await act(async () => await user.click(filterOptionACS));
 
           const filterModal = screen.getByTestId("Filtro");
           const btnApplyFilter = within(filterModal).getByRole("button", { name: /filtrar lista nominal/i });
-          await user.click(btnApplyFilter);
+          await act(async () => await user.click(btnApplyFilter));
 
-          await user.click(btnShowFilterModal);
-          await user.click(showACSFilterOptions);
-          await user.click(filterOptionACS);
-          await user.click(btnApplyFilter);
+          await act(async () => await user.click(btnShowFilterModal));
+          await act(async () => await user.click(showACSFilterOptions));
+          await act(async () => await user.click(filterOptionACS));
+          await act(async () => await user.click(btnApplyFilter));
 
           const rows = screen.getAllByRole("row");
 
@@ -626,7 +623,7 @@ describe(`Componente: ${COMPONENT}`, () => {
         render(<PainelBuscaAtiva { ...scenarios[0] } />);
 
         const searchInput = screen.getByPlaceholderText(/pesquise um nome/i);
-        await user.type(searchInput, "ca");
+        await act(async () => await user.type(searchInput, "ca"));
 
         const rows = screen.getAllByRole("row");
 

--- a/componentes/PainelBuscaAtiva/components/Filtro/Filtro.test.js
+++ b/componentes/PainelBuscaAtiva/components/Filtro/Filtro.test.js
@@ -138,7 +138,7 @@ describe('Componente: Filtro', () => {
       const user = userEvent.setup();
       render(<Filtro {...scenarios[0]} />);
 
-      const botaoFiltrarLista = await screen.findByRole('button', {
+      const botaoFiltrarLista = screen.getByRole('button', {
         name: /filtrar lista nominal/i
       });
 
@@ -152,7 +152,7 @@ describe('Componente: Filtro', () => {
         const user = userEvent.setup();
         render(<Filtro {...scenarios[0]} />);
 
-        const botaoFiltrarLista = await screen.findByRole('button', {
+        const botaoFiltrarLista = screen.getByRole('button', {
           name: /filtrar lista nominal/i
         });
 
@@ -168,7 +168,7 @@ describe('Componente: Filtro', () => {
           const user = userEvent.setup();
           render(<Filtro {...scenarios[1]} />);
 
-          const botaoFiltrarLista = await screen.findByRole('button', {
+          const botaoFiltrarLista = screen.getByRole('button', {
             name: /filtrar lista nominal/i
           });
 
@@ -200,7 +200,7 @@ describe('Componente: Filtro', () => {
           const user = userEvent.setup();
           render(<Filtro {...scenarios[2]} />);
 
-          const botaoFiltrarLista = await screen.findByRole('button', {
+          const botaoFiltrarLista = screen.getByRole('button', {
             name: /filtrar lista nominal/i
           });
 
@@ -267,7 +267,7 @@ describe('Componente: Filtro', () => {
         const user = userEvent.setup();
         render(<Filtro {...scenarios[3]} />);
 
-        const botaoFiltrarLista = await screen.findByRole('button', {
+        const botaoFiltrarLista = screen.getByRole('button', {
           name: /filtrar lista nominal/i
         });
 
@@ -300,7 +300,7 @@ describe('Componente: Filtro', () => {
       const user = userEvent.setup();
       render(<Filtro {...scenarios[0]} />);
 
-      const limparFiltros = await screen.findByText(/limpar filtros/i);
+      const limparFiltros = screen.getByText(/limpar filtros/i);
 
       await user.click(limparFiltros);
 
@@ -312,7 +312,7 @@ describe('Componente: Filtro', () => {
         const user = userEvent.setup();
         render(<Filtro {...scenarios[0]} />);
 
-        const limparFiltros = await screen.findByText(/limpar filtros/i);
+        const limparFiltros = screen.getByText(/limpar filtros/i);
 
         await user.click(limparFiltros);
 
@@ -325,7 +325,7 @@ describe('Componente: Filtro', () => {
         const user = userEvent.setup();
         render(<Filtro {...scenarios[4]} />);
 
-        const limparFiltros = await screen.findByText(/limpar filtros/i);
+        const limparFiltros = screen.getByText(/limpar filtros/i);
 
         await user.click(limparFiltros);
 

--- a/componentes/PainelBuscaAtiva/components/FiltroBody/FiltroBody.test.js
+++ b/componentes/PainelBuscaAtiva/components/FiltroBody/FiltroBody.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FiltroBody } from './FiltroBody';
 
@@ -57,15 +57,11 @@ describe(`Componente: ${COMPONENT}`, () => {
 
       render(<FiltroBody { ...scenarios[1] } />);
 
-      const label = await screen.findByText(FILTER_LABEL);
       const showOptionsButton = screen.getByRole('button', { name: '+' });
+      await act(async () => await user.click(showOptionsButton));
 
-      await user.click(showOptionsButton);
-
-      const hideOptionsButton = await screen.findByRole('button', { name: '-' });
-
-      expect(label).toBeInTheDocument();
-      expect(hideOptionsButton).toBeInTheDocument();
+      expect(screen.getByText(FILTER_LABEL)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '-' })).toBeInTheDocument();
     });
 
     it('deve renderizar todas as opções de filtro em ordem crescente quando são strings não numéricas', async () => {
@@ -73,11 +69,10 @@ describe(`Componente: ${COMPONENT}`, () => {
 
       render(<FiltroBody { ...scenarios[1] } />);
 
-      const showOptionsButton = await screen.findByRole('button', { name: '+' });
+      const showOptionsButton = screen.getByRole('button', { name: '+' });
+      await act(async () => await user.click(showOptionsButton));
 
-      await user.click(showOptionsButton);
-
-      const options = await screen.findAllByTestId('FiltroCardLabel');
+      const options = screen.getAllByTestId('FiltroCardLabel');
 
       expect(options).toHaveLength(2);
       expect(options[0]).toHaveTextContent(OPTION_1);
@@ -89,11 +84,10 @@ describe(`Componente: ${COMPONENT}`, () => {
 
       render(<FiltroBody { ...scenarios[3] } />);
 
-      const showOptionsButton = await screen.findByRole('button', { name: '+' });
+      const showOptionsButton = screen.getByRole('button', { name: '+' });
+      await act(async () => await user.click(showOptionsButton));
 
-      await user.click(showOptionsButton);
-
-      const options = await screen.findAllByTestId('FiltroCardLabel');
+      const options = screen.getAllByTestId('FiltroCardLabel');
 
       expect(options).toHaveLength(2);
       expect(options[0]).toHaveTextContent(LABEL_1);
@@ -108,12 +102,11 @@ describe(`Componente: ${COMPONENT}`, () => {
 
         render(<FiltroBody { ...scenarios[2] } />);
 
-        const showOptionsButton = await screen.findByRole('button', { name: '+' });
+        const showOptionsButton = screen.getByRole('button', { name: '+' });
+        await act(async () => await user.click(showOptionsButton));
 
-        await user.click(showOptionsButton);
-
-        expect(await screen.findByText(OPTION_1)).toBeInTheDocument();
-        expect(await screen.findByText(OPTION_2)).toBeInTheDocument();
+        expect(screen.getByText(OPTION_1)).toBeInTheDocument();
+        expect(screen.getByText(OPTION_2)).toBeInTheDocument();
         expect(screen.queryByText(LABEL_1)).not.toBeInTheDocument();
         expect(screen.queryByText(LABEL_2)).not.toBeInTheDocument();
       });
@@ -125,12 +118,11 @@ describe(`Componente: ${COMPONENT}`, () => {
 
         render(<FiltroBody { ...scenarios[3] } />);
 
-        const showOptionsButton = await screen.findByRole('button', { name: '+' });
+        const showOptionsButton = screen.getByRole('button', { name: '+' });
+        await act(async () => await user.click(showOptionsButton));
 
-        await user.click(showOptionsButton);
-
-        expect(await screen.findByText(LABEL_1)).toBeInTheDocument();
-        expect(await screen.findByText(LABEL_2)).toBeInTheDocument();
+        expect(screen.getByText(LABEL_1)).toBeInTheDocument();
+        expect(screen.getByText(LABEL_2)).toBeInTheDocument();
         expect(screen.queryByText('1')).not.toBeInTheDocument();
         expect(screen.queryByText('0')).not.toBeInTheDocument();
       });
@@ -143,16 +135,14 @@ describe(`Componente: ${COMPONENT}`, () => {
 
       render(<FiltroBody { ...scenarios[0] } />);
 
-      const showOptionsButton = await screen.findByRole('button', { name: '+' });
+      const showOptionsButton = screen.getByRole('button', { name: '+' });
+      await act(async () => await user.click(showOptionsButton));
 
-      await user.click(showOptionsButton);
+      const hideOptionsButton = screen.getByRole('button', { name: '-' });
+      await act(async () => await user.click(hideOptionsButton));
 
-      const hideOptionsButton = await screen.findByRole('button', { name: '-' });
-
-      await user.click(hideOptionsButton);
-
-      expect(await screen.findByText(FILTER_LABEL)).toBeInTheDocument();
-      expect(await screen.findByRole('button', { name: '+' })).toBeInTheDocument();
+      expect(screen.getByText(FILTER_LABEL)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '+' })).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: '-' })).not.toBeInTheDocument();
     });
   });

--- a/componentes/PainelBuscaAtiva/components/ToolBar/ToolBar.test.js
+++ b/componentes/PainelBuscaAtiva/components/ToolBar/ToolBar.test.js
@@ -171,6 +171,10 @@ const scenario = [
 ];
 
 describe(`Componente: ${COMPONENT}`, () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('deve renderizar corretamente', () => {
     render(
       <ToolBar {...scenario[0]} />,
@@ -188,9 +192,9 @@ describe(`Componente: ${COMPONENT}`, () => {
     const input = screen.getByPlaceholderText('PESQUISE UM NOME');
     await act(async () => await user.type(input, 'Maria'));
 
-    expect(scenario[0].updateData).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
+    expect(scenario[0].updateData).toHaveBeenLastCalledWith(
+      [
+        {
           paciente_nome: "Maria da Silva",
           cidadao_cpf_dt_nascimento: "327.327.327-32",
           id_status_usuario: 12,
@@ -205,8 +209,8 @@ describe(`Componente: ${COMPONENT}`, () => {
           ine_master: "0002277227",
           equipe_nome: "ESF 1",
           dt_registro_producao_mais_recente: "2023-10-22"
-        })
-      ])
+        }
+      ]
     );
   });
 
@@ -218,9 +222,8 @@ describe(`Componente: ${COMPONENT}`, () => {
     const input = screen.getByPlaceholderText('PESQUISE UM NOME');
     await act(async () => await user.type(input, 'Julia'));
 
-    expect(scenario[1].updateData).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
+    expect(scenario[1].updateData).toHaveBeenLastCalledWith([
+        {
           cidadao_nome: "Julia da Silva",
           cidadao_cpf_dt_nascimento: "100.100.100-10",
           id_status_usuario: 12,
@@ -235,8 +238,8 @@ describe(`Componente: ${COMPONENT}`, () => {
           ine_master: "0000369369",
           equipe_nome: "ESF 2",
           dt_registro_producao_mais_recente: "2023-10-22"
-        })
-      ])
+        }
+      ]
     );
   });
 

--- a/componentes/PainelBuscaAtiva/components/ToolBar/ToolBar.test.js
+++ b/componentes/PainelBuscaAtiva/components/ToolBar/ToolBar.test.js
@@ -1,4 +1,4 @@
-import {render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {ToolBar} from './index';
 
@@ -186,7 +186,7 @@ describe(`Componente: ${COMPONENT}`, () => {
     render(<ToolBar {...scenario[0]} />);
 
     const input = screen.getByPlaceholderText('PESQUISE UM NOME');
-    await user.type(input, 'Maria');
+    await act(async () => await user.type(input, 'Maria'));
 
     expect(scenario[0].updateData).toHaveBeenCalledWith(
       expect.arrayContaining([
@@ -216,7 +216,7 @@ describe(`Componente: ${COMPONENT}`, () => {
     render(<ToolBar {...scenario[1]} />);
 
     const input = screen.getByPlaceholderText('PESQUISE UM NOME');
-    await user.type(input, 'Julia');
+    await act(async () => await user.type(input, 'Julia'));
 
     expect(scenario[1].updateData).toHaveBeenCalledWith(
       expect.arrayContaining([


### PR DESCRIPTION
### Contexto
Os testes desenvolvidos para os componentes do design system estavam emitindo o aviso de que o `act` deveria ser usado quando eventos que geravam atualização de estados dos componentes eram disparados, como clicks em botões e escrita em campos de texto.

Esses avisos apareciam sempre que os testes eram executados, dificultando a leitura da saída dos comandos do Jest e indicando que os testes executados poderiam não estar abrangendo as atualizações do componente após interações.

### Objetivos
- Disparar os eventos que atualizam estados dos componentes dentro do `act`
- Corrigir testes da ToolBar que geravam falso positivo
- Remover o uso de queries RTL do tipo `findBy` que poderiam ser substituídas sem problemas por queries do tipo `getBy`

### Checklist de validação
- [ ] Ao executar o comando `npm t`, todos os testes passam e o aviso de uso do `act` não é emitido
- [ ] Ao executar o comando `npm run test:coverage`, o relatório gerado aponta 20.05% de linhas cobertas