### PR TITLE
[CardImg] Adiciona prop imagemStyle e ajusta posição da imagem

### DIFF
--- a/componentes/CardImg/CardImg.jsx
+++ b/componentes/CardImg/CardImg.jsx
@@ -7,7 +7,8 @@ const CardImg = ({
   imagemSrc,
   indicador,
   descricao,
-  height
+  height,
+  imagemStyle,
 }) => {
   return (
     <div
@@ -18,6 +19,7 @@ const CardImg = ({
       <div className={style.CardInfoImagemContainer}>
         {imagemSrc && (
           <img
+            style={{...imagemStyle}}
             src={imagemSrc}
             alt="Imagem do card"
             className={style.CardInfoImagem}
@@ -40,13 +42,15 @@ const CardImg = ({
 CardImg.defaultProps = {
   height: "100%",
   imagemSrc: "",
+  imagemStyle: {},
 }
 
 CardImg.propTypes = {
   height: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
-  ])
+  ]),
+  imagemStyle: PropTypes.object,
 }
 
 export { CardImg };

--- a/componentes/CardImg/CardImg.module.css
+++ b/componentes/CardImg/CardImg.module.css
@@ -71,7 +71,7 @@
 
 .CardInfoImagemContainer {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center; 
   margin-bottom: 16px; 
 }

--- a/componentes/CardImg/CardImg.stories.js
+++ b/componentes/CardImg/CardImg.stories.js
@@ -21,6 +21,10 @@ export default {
       name: "height",
       description: "Altura atribuída ao card *string* ou *number*"
     },
+    imagemStyle: {
+      name: "imagemStyle",
+      description: "Estilo aplicado à imagem *object*"
+    },
   }
 }
 const Template = (args) => <CardImg {...args}/>
@@ -28,5 +32,8 @@ export const Completo = Template.bind({});
 Completo.args={
     indicador:"Conteúdos e materiais com dicas",
     descricao:"Semanalmente enviamos para o seu e-mail sugestões para melhorar sua rotina de trabalho e mantemos você informado sobre as atualizações da APS.",
-    imagemSrc: "url_da_sua_imagem",
+    imagemSrc: "https://media.graphassets.com/7KgUfR5QK24Tgxw79bIQ",
+    imagemStyle: {
+      height: "40vh"
+    }
 }


### PR DESCRIPTION
### Contexto
A partir das mudanças de layout aplicadas na área aberta do IP devido à queda do Previne Brasil, foi necessário fazer ajustes  no componente `CardImg` para adequá-lo ao novo contexto de uso.

### Objetivos
- Adicionar prop `imagemStyle` para controlar estilo aplicado à imagem do card
- Posicionar a imagem do card à esquerda

### Checklist de validação
- [ ] É possível controlar o estilo aplicado à imagem do card a partir da prop `imagemStyle`
- [ ] A imagem do card está posicionada à esquerda