### PR TITLE
[CardAlert] Adiciona prop fontSize

### DIFF
--- a/componentes/CardAlert/CardAlert.jsx
+++ b/componentes/CardAlert/CardAlert.jsx
@@ -8,13 +8,15 @@ const CardAlert = ({
     background,
     margin,
     padding,
-    color
+    color,
+    fontSize
 })=>{
     const cardStyle = {
         background: background || "#F4CCAB",
         margin : margin || "0px 80px",
         padding: padding || "10px 16px",
-        color: color || "#1F1F1F"
+        color: color || "#1F1F1F",
+        fontSize: fontSize || "14px",
       };
     return(
         <div className={style.CardAlert} style={cardStyle}>


### PR DESCRIPTION
### Contexto
A partir dessa [tarefa](https://www.notion.so/impulsogov/Dados-P-blicos-Incluir-mensagem-sobre-o-fim-do-programa-d82ac244adf74892a050a2d207707408?pvs=4), foi necessário alterar o tamanho da fonte usada no CardAlert, que possuía um valor fixo para essa propriedade CSS.

### Objetivos
- Permitir controle externo do tamanho da fonte usada no card

### Checklist de validação
- [ ] O CardAlert recebe uma a prop `fontSize` que controla o tamanho da fonte do texto quando ela é passada para o componente
- [ ] É possível controlar o estilo aplicado à imagem do card a partir da prop `imagemStyle` e sua imagem está posicionada à esquerda