### PR TITLE
Ajustes quick wins pacote 5

### DIFF
--- a/componentes/CardAlert/CardAlert.jsx
+++ b/componentes/CardAlert/CardAlert.jsx
@@ -8,15 +8,13 @@ const CardAlert = ({
     background,
     margin,
     padding,
-    color,
-    fontSize
+    color
 })=>{
     const cardStyle = {
         background: background || "#F4CCAB",
         margin : margin || "0px 80px",
         padding: padding || "10px 16px",
-        color: color || "#1F1F1F",
-        fontSize: fontSize || "14px",
+        color: color || "#1F1F1F"
       };
     return(
         <div className={style.CardAlert} style={cardStyle}>

--- a/componentes/CardAlert/CardAlert.jsx
+++ b/componentes/CardAlert/CardAlert.jsx
@@ -8,13 +8,15 @@ const CardAlert = ({
     background,
     margin,
     padding,
-    color
+    color,
+    fontSize
 })=>{
     const cardStyle = {
         background: background || "#F4CCAB",
         margin : margin || "0px 80px",
         padding: padding || "10px 16px",
-        color: color || "#1F1F1F"
+        color: color || "#1F1F1F",
+        fontSize: fontSize || "14px",
       };
     return(
         <div className={style.CardAlert} style={cardStyle}>

--- a/componentes/CardImg/CardImg.jsx
+++ b/componentes/CardImg/CardImg.jsx
@@ -7,7 +7,8 @@ const CardImg = ({
   imagemSrc,
   indicador,
   descricao,
-  height
+  height,
+  imagemStyle,
 }) => {
   return (
     <div
@@ -18,6 +19,7 @@ const CardImg = ({
       <div className={style.CardInfoImagemContainer}>
         {imagemSrc && (
           <img
+            style={{...imagemStyle}}
             src={imagemSrc}
             alt="Imagem do card"
             className={style.CardInfoImagem}
@@ -40,13 +42,15 @@ const CardImg = ({
 CardImg.defaultProps = {
   height: "100%",
   imagemSrc: "",
+  imagemStyle: {},
 }
 
 CardImg.propTypes = {
   height: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
-  ])
+  ]),
+  imagemStyle: PropTypes.object,
 }
 
 export { CardImg };

--- a/componentes/CardImg/CardImg.module.css
+++ b/componentes/CardImg/CardImg.module.css
@@ -71,7 +71,7 @@
 
 .CardInfoImagemContainer {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center; 
   margin-bottom: 16px; 
 }

--- a/componentes/CardImg/CardImg.stories.js
+++ b/componentes/CardImg/CardImg.stories.js
@@ -21,6 +21,10 @@ export default {
       name: "height",
       description: "Altura atribuída ao card *string* ou *number*"
     },
+    imagemStyle: {
+      name: "imagemStyle",
+      description: "Estilo aplicado à imagem *object*"
+    },
   }
 }
 const Template = (args) => <CardImg {...args}/>
@@ -28,5 +32,8 @@ export const Completo = Template.bind({});
 Completo.args={
     indicador:"Conteúdos e materiais com dicas",
     descricao:"Semanalmente enviamos para o seu e-mail sugestões para melhorar sua rotina de trabalho e mantemos você informado sobre as atualizações da APS.",
-    imagemSrc: "url_da_sua_imagem",
+    imagemSrc: "https://media.graphassets.com/7KgUfR5QK24Tgxw79bIQ",
+    imagemStyle: {
+      height: "40vh"
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@impulsogov/design-system",
-  "version": "1.0.211",
+  "version": "1.0.212",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@impulsogov/design-system",
-      "version": "1.0.211",
+      "version": "1.0.212",
       "dependencies": {
         "@babel/cli": "^7.18.9",
         "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@impulsogov/design-system",
   "description": "Impulso Gov Design System",
-  "version": "1.0.211",
+  "version": "1.0.212",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [


### PR DESCRIPTION
### Contexto
A partir das mudanças de layout aplicadas na área aberta do IP devido à queda do Previne Brasil, foi necessário fazer ajustes  nos componentes `CardImg` para adequá-los ao novo contexto de uso.

### Objetivos
- Adicionar prop `imagemStyle` para controlar estilo aplicado à imagem do card
- Posicionar a imagem do card à esquerda

### Checklist de validação
- [ ] É possível controlar o estilo aplicado à imagem do card a partir da prop `imagemStyle`
- [ ] A imagem do card está posicionada à esquerda