### PR TITLE
Cria modal de personalização da impressão

### DIFF
--- a/componentes/ModalAlert/ModalAlert.jsx
+++ b/componentes/ModalAlert/ModalAlert.jsx
@@ -3,6 +3,7 @@ import style from "./ModalAlert.module.css";
 import style_v2 from "./ModalAlertV2.module.css";
 import style_v3 from "./ModalAlertV3.module.css";
 import style_v4 from "./ModalAlertV4.module.css";
+import styleControlled from "./ModalAlertControlled.module.css";
 import { ButtonColor,ButtonColorMobile, ButtonColorSubmit } from "../ButtonColor";
 
 const CardProfissional = ({cardProfissional})=>{
@@ -289,4 +290,18 @@ const ModalAlertOff= ({Child,childProps,display,setDisplay})=>{
     )
 }
 
-export { ModalAlert,Alert,CardAlertModal,ModalAlertOff,NPS, Alert_v2, AtualizacaoCadastral , Alert_v4 }
+const ModalAlertControlled = ({children, display, close})=>{
+      return(
+            display &&(
+            <div className={styleControlled.Modal}> 
+                {children}
+                <div
+                    className={styleControlled.BlurArea}
+                    onClick={close}
+                />
+            </div>
+        )
+    )
+}
+
+export { ModalAlert,Alert,CardAlertModal,ModalAlertOff,NPS, Alert_v2, AtualizacaoCadastral , Alert_v4, ModalAlertControlled }

--- a/componentes/ModalAlert/ModalAlertControlled.module.css
+++ b/componentes/ModalAlert/ModalAlertControlled.module.css
@@ -1,0 +1,17 @@
+.Modal {
+    width: 100%;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    top: 0;
+}
+
+.BlurArea {
+    width: 100%;
+    height: 100vh;
+    position: fixed;
+    z-index: 1;
+    background-color: rgba(0, 0, 0, 0.5);
+}

--- a/componentes/ModalAlert/index.js
+++ b/componentes/ModalAlert/index.js
@@ -1,1 +1,1 @@
-export { ModalAlert, Alert, CardAlertModal, NPS , Alert_v2 , AtualizacaoCadastral, Alert_v4 } from "./ModalAlert"
+export { ModalAlert, Alert, CardAlertModal, NPS , Alert_v2 , AtualizacaoCadastral, Alert_v4, ModalAlertControlled } from "./ModalAlert"

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -98,6 +98,8 @@ const status_usuario_descricao = [
     }
 ]
 
+const VALORES_AGRUPAMENTO_IMPRESSAO = { sim: "sim", nao: "não" };
+
 const PainelBuscaAtiva = ({
     tabela,
     dadosFiltros,
@@ -136,6 +138,20 @@ const PainelBuscaAtiva = ({
             orientation: 'landscape'
         }
     });
+    const [personalizacao, setPersonalizacao] = useState({
+        agrupamento: VALORES_AGRUPAMENTO_IMPRESSAO.sim,
+        separacaoGrupoPorFolha: false,
+        ordenacao: false,
+    });
+
+    function handlePersonalizacaoChange(e) {
+        const { name, value, checked, type } = e.target;
+
+        setPersonalizacao({
+            ...personalizacao,
+            [name]: type === "checkbox" ? checked : value
+        });
+    }
 
     function updateData(newData){
         setData(newData);
@@ -208,15 +224,20 @@ const PainelBuscaAtiva = ({
         setShowImpressao(false)
     }
 
-    const handleModalImpressaoClick = () => {
-        const equipesFiltradas = helpers.buscarFiltroPorPropriedade(chavesFiltros, propAgrupamentoImpressao);
+    const processarPedidoDeImpressao = () => {
+        const filtros = helpers.buscarFiltroPorPropriedade(chavesFiltros, propAgrupamentoImpressao);
 
-        equipesFiltradas.length === 1
+        filtros.length === 1
             ? handlePrintClick()
             : setShowModalImpressao(true);
     }
 
     const fecharModalImpressao = () => setShowModalImpressao(false)
+
+    const personalizarImpressao = () => {
+        handlePrintClick();
+        fecharModalImpressao();
+    }
 
     return(
         <div style={{marginTop : "30px"}} data-testid="PainelBuscaAtiva">
@@ -292,7 +313,7 @@ const PainelBuscaAtiva = ({
                 updateData={updateData}
                 tabela={tabela.data}
                 ordenacaoAplicada={ordenacaoAplicada}
-                handlePrintClick={handleModalImpressaoClick}
+                handlePrintClick={painel === "aps" ? processarPedidoDeImpressao : handlePrintClick}
             />
             <TabelaHiperDia
                 colunas={tabela.colunas}
@@ -319,7 +340,7 @@ const PainelBuscaAtiva = ({
                     titulo="PERSONALIZAR A IMPRESSÃO"
                     labelsPersonalizacaoPrincipal={{
                         titulo: "Deseja fazer uma impressão personalizada por Equipes?",
-                        descricao: "A impressão personalizada agrupa os pacientes de acordo com as Equipes correspondentes. Qualquer filtrou ou ordenação selecionados anteriormente serão mantidos e aplicados dentro do agrupamento por equipes",
+                        descricao: "A impressão personalizada agrupa os pacientes de acordo com as Equipes correspondentes. Qualquer filtro ou ordenação selecionados anteriormente serão mantidos e aplicados dentro do agrupamento por equipes",
                         agrupamentoSim: "Sim",
                         agrupamentoNao: "Não",
                     }}
@@ -331,9 +352,12 @@ const PainelBuscaAtiva = ({
                     }}
                     botao={{
                         label: "IMPRIMIR LISTA",
-                        handleClick: () => {},
+                        handleClick: personalizarImpressao,
                     }}
                     handleClose={fecharModalImpressao}
+                    handleChange={handlePersonalizacaoChange}
+                    valoresAgrupamento={VALORES_AGRUPAMENTO_IMPRESSAO}
+                    personalizacao={personalizacao}
                 />
             </ModalAlertControlled>
             {

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -208,7 +208,7 @@ const PainelBuscaAtiva = ({
         setShowImpressao(false)
     }
 
-    const mostrarModalImpressao = () => {
+    const handleModalImpressaoClick = () => {
         const equipesFiltradas = helpers.buscarFiltroPorPropriedade(chavesFiltros, propAgrupamentoImpressao);
 
         equipesFiltradas.length === 1
@@ -292,7 +292,7 @@ const PainelBuscaAtiva = ({
                 updateData={updateData}
                 tabela={tabela.data}
                 ordenacaoAplicada={ordenacaoAplicada}
-                handlePrintClick={mostrarModalImpressao}
+                handlePrintClick={handleModalImpressaoClick}
             />
             <TabelaHiperDia
                 colunas={tabela.colunas}

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -118,6 +118,7 @@ const PainelBuscaAtiva = ({
     TabelaImpressao,
     showSnackBar,
     setShowSnackBar,
+    propAgrupamentoImpressao = "",
 })=>{
     const [tableData, setTableData] = useState(tabela.data)
     const [showOrdenarModal,setShowOrdenarModal] = useState(false)
@@ -206,8 +207,16 @@ const PainelBuscaAtiva = ({
         await imprimirPDF()
         setShowImpressao(false)
     }
-    const mostrarModalImpressao = ()=> setShowModalImpressao(true)
-    const fecharModalImpressao = ()=> setShowModalImpressao(false)
+
+    const mostrarModalImpressao = () => {
+        const equipesFiltradas = helpers.buscarFiltroPorPropriedade(chavesFiltros, propAgrupamentoImpressao);
+
+        equipesFiltradas.length === 1
+            ? handlePrintClick()
+            : setShowModalImpressao(true);
+    }
+
+    const fecharModalImpressao = () => setShowModalImpressao(false)
 
     return(
         <div style={{marginTop : "30px"}} data-testid="PainelBuscaAtiva">
@@ -333,7 +342,7 @@ const PainelBuscaAtiva = ({
             {
                 showImpressao &&
                 <TabelaImpressao
-                    data={tabela.data}
+                    data={tableData}
                     colunas={tabela.colunas}
                     status_usuario_descricao={{ data: status_usuario_descricao }}
                     targetRef={targetRef}

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -234,6 +234,7 @@ const PainelBuscaAtiva = ({
         filtros.length === NUMERO_DE_FILTROS_PARA_IMPRESSAO_DIRETA
             ? handlePrintClick()
             : setShowModalImpressao(true);
+        onPrintClick();
     }
 
     const fecharModalImpressao = () => setShowModalImpressao(false)
@@ -246,7 +247,6 @@ const PainelBuscaAtiva = ({
                 : tableData
         );
         handlePrintClick();
-        onPrintClick();
         fecharModalImpressao();
     }
 
@@ -324,7 +324,13 @@ const PainelBuscaAtiva = ({
                 updateData={updateData}
                 tabela={tabela.data}
                 ordenacaoAplicada={ordenacaoAplicada}
-                handlePrintClick={painel === "aps" ? processarPedidoDeImpressao : handlePrintClick}
+                handlePrintClick={painel === "aps"
+                    ? processarPedidoDeImpressao
+                    : () => {
+                        handlePrintClick();
+                        onPrintClick();
+                    }
+                }
             />
             <TabelaHiperDia
                 colunas={tabela.colunas}

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -316,25 +316,22 @@ const PainelBuscaAtiva = ({
                 close={fecharModalImpressao}
             >
                 <PersonalizacaoImpressao
-                    labels={{
-                        titulo: "PERSONALIZAR A IMPRESSÃO",
-                        personalizacaoPrincipal: {
-                            titulo: "Deseja fazer uma impressão personalizada por Equipes?",
-                            descricao: "A impressão personalizada agrupa os pacientes de acordo com as Equipes correspondentes. Qualquer filtrou ou ordenação selecionados anteriormente serão mantidos e aplicados dentro do agrupamento por equipes",
-                            opcoes: {
-                            agrupamentoSim: "Sim",
-                            agrupamentoNao: "Não",
-                            },
-                        },
-                        personalizacaoSecundaria: {
-                            titulo: "Outras personalizações de impressão:",
-                            recomendacao: "Recomendadas para distribuição para coordenadoras de equipe",
-                            opcoes: {
-                            separacaoGrupoPorFolha: "Imprimir grupos de pacientes por Equipes em folhas separadas",
-                            ordenacao: "Ordenar pacientes por ACS",
-                            },
-                        },
-                        botao: "IMPRIMIR LISTA",
+                    titulo="PERSONALIZAR A IMPRESSÃO"
+                    labelsPersonalizacaoPrincipal={{
+                        titulo: "Deseja fazer uma impressão personalizada por Equipes?",
+                        descricao: "A impressão personalizada agrupa os pacientes de acordo com as Equipes correspondentes. Qualquer filtrou ou ordenação selecionados anteriormente serão mantidos e aplicados dentro do agrupamento por equipes",
+                        agrupamentoSim: "Sim",
+                        agrupamentoNao: "Não",
+                    }}
+                    labelsPersonalizacaoSecundaria={{
+                        titulo: "Outras personalizações de impressão:",
+                        recomendacao: "Recomendadas para distribuição para coordenadoras de equipe",
+                        separacaoGrupoPorFolha: "Imprimir grupos de pacientes por Equipes em folhas separadas",
+                        ordenacao: "Ordenar pacientes por ACS",
+                    }}
+                    botao={{
+                        label: "IMPRIMIR LISTA",
+                        handleClick: () => {},
                     }}
                     handleClose={fecharModalImpressao}
                 />

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -99,6 +99,7 @@ const status_usuario_descricao = [
 ]
 
 const VALORES_AGRUPAMENTO_IMPRESSAO = { sim: "sim", nao: "não" };
+const NUMERO_DE_FILTROS_PARA_IMPRESSAO_DIRETA = 1;
 
 const PainelBuscaAtiva = ({
     tabela,
@@ -121,6 +122,7 @@ const PainelBuscaAtiva = ({
     showSnackBar,
     setShowSnackBar,
     propAgrupamentoImpressao = "",
+    propOrdenacaoImpressao = "",
     labelsModalImpressao = {
         titulo: "",
         personalizacaoPrincipal: {},
@@ -129,6 +131,7 @@ const PainelBuscaAtiva = ({
     },
 })=>{
     const [tableData, setTableData] = useState(tabela.data)
+    const [dadosImpressao, setDadosImpressao] = useState(tabela.data);
     const [showOrdenarModal,setShowOrdenarModal] = useState(false)
     const [showFiltrosModal,setShowFiltrosModal] = useState(false)
     const [ordenar,setOrdenar] = useState('1')
@@ -150,14 +153,9 @@ const PainelBuscaAtiva = ({
         ordenacao: false,
     });
 
-    function handlePersonalizacaoChange(e) {
-        const { name, value, checked, type } = e.target;
-
-        setPersonalizacao({
-            ...personalizacao,
-            [name]: type === "checkbox" ? checked : value
-        });
-    }
+    useEffect(() => {
+        setDadosImpressao(tableData);
+    }, [tableData])
 
     function updateData(newData){
         setData(newData);
@@ -233,14 +231,20 @@ const PainelBuscaAtiva = ({
     const processarPedidoDeImpressao = () => {
         const filtros = helpers.buscarFiltroPorPropriedade(chavesFiltros, propAgrupamentoImpressao);
 
-        filtros.length === 1
+        filtros.length === NUMERO_DE_FILTROS_PARA_IMPRESSAO_DIRETA
             ? handlePrintClick()
             : setShowModalImpressao(true);
     }
 
     const fecharModalImpressao = () => setShowModalImpressao(false)
 
-    const personalizarImpressao = () => {
+    const personalizarImpressao = (opcoes) => {
+        setPersonalizacao(opcoes);
+        setDadosImpressao(
+            opcoes.ordenacao && opcoes.agrupamento === VALORES_AGRUPAMENTO_IMPRESSAO.sim
+                ? helpers.sortByString(tableData, propOrdenacaoImpressao)
+                : tableData
+        );
         handlePrintClick();
         fecharModalImpressao();
     }
@@ -346,19 +350,19 @@ const PainelBuscaAtiva = ({
                     labels={labelsModalImpressao}
                     handleButtonClick={personalizarImpressao}
                     handleClose={fecharModalImpressao}
-                    handleChange={handlePersonalizacaoChange}
                     valoresAgrupamento={VALORES_AGRUPAMENTO_IMPRESSAO}
-                    personalizacao={personalizacao}
                 />
             </ModalAlertControlled>
             {
                 showImpressao &&
                 <TabelaImpressao
-                    data={tableData}
+                    data={dadosImpressao}
                     colunas={tabela.colunas}
                     status_usuario_descricao={{ data: status_usuario_descricao }}
                     targetRef={targetRef}
                     fontFamily="sans-serif"
+                    divisao_dados={personalizacao.agrupamento === VALORES_AGRUPAMENTO_IMPRESSAO.sim}
+                    divisao_paginas={personalizacao.separacaoGrupoPorFolha}
                 />
             }
         </div>

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -246,6 +246,7 @@ const PainelBuscaAtiva = ({
                 : tableData
         );
         handlePrintClick();
+        onPrintClick();
         fecharModalImpressao();
     }
 

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -121,6 +121,12 @@ const PainelBuscaAtiva = ({
     showSnackBar,
     setShowSnackBar,
     propAgrupamentoImpressao = "",
+    labelsModalImpressao = {
+        titulo: "",
+        personalizacaoPrincipal: {},
+        personalizacaoSecundaria: {},
+        botao: "",
+    },
 })=>{
     const [tableData, setTableData] = useState(tabela.data)
     const [showOrdenarModal,setShowOrdenarModal] = useState(false)
@@ -337,23 +343,8 @@ const PainelBuscaAtiva = ({
                 close={fecharModalImpressao}
             >
                 <PersonalizacaoImpressao
-                    titulo="PERSONALIZAR A IMPRESSÃO"
-                    labelsPersonalizacaoPrincipal={{
-                        titulo: "Deseja fazer uma impressão personalizada por Equipes?",
-                        descricao: "A impressão personalizada agrupa os pacientes de acordo com as Equipes correspondentes. Qualquer filtro ou ordenação selecionados anteriormente serão mantidos e aplicados dentro do agrupamento por equipes",
-                        agrupamentoSim: "Sim",
-                        agrupamentoNao: "Não",
-                    }}
-                    labelsPersonalizacaoSecundaria={{
-                        titulo: "Outras personalizações de impressão:",
-                        recomendacao: "Recomendadas para distribuição para coordenadoras de equipe",
-                        separacaoGrupoPorFolha: "Imprimir grupos de pacientes por Equipes em folhas separadas",
-                        ordenacao: "Ordenar pacientes por ACS",
-                    }}
-                    botao={{
-                        label: "IMPRIMIR LISTA",
-                        handleClick: personalizarImpressao,
-                    }}
+                    labels={labelsModalImpressao}
+                    handleButtonClick={personalizarImpressao}
                     handleClose={fecharModalImpressao}
                     handleChange={handlePersonalizacaoChange}
                     valoresAgrupamento={VALORES_AGRUPAMENTO_IMPRESSAO}

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.jsx
@@ -7,6 +7,8 @@ import { CardAlert } from "../CardAlert";
 import * as Components from "./components";
 import * as helpers from "./helpers";
 import generatePDF,{ usePDF } from 'react-to-pdf';
+import { PersonalizacaoImpressao } from "../PersonalizacaoImpressao/PersonalizacaoImpressao";
+import { ModalAlertControlled } from "../ModalAlert/ModalAlert";
 
 const status_usuario_descricao = [
     {
@@ -125,6 +127,7 @@ const PainelBuscaAtiva = ({
     const [modal,setModal] = useState(false)
     const [chavesFiltros,setChavesFiltros] = useState([])
     const [showImpressao,setShowImpressao] = useState(false)
+    const [showModalImpressao, setShowModalImpressao] = useState(false);
     const { toPDF, targetRef } = usePDF({
         filename: 'page.pdf',
         method : 'open',
@@ -203,6 +206,9 @@ const PainelBuscaAtiva = ({
         await imprimirPDF()
         setShowImpressao(false)
     }
+    const mostrarModalImpressao = ()=> setShowModalImpressao(true)
+    const fecharModalImpressao = ()=> setShowModalImpressao(false)
+
     return(
         <div style={{marginTop : "30px"}} data-testid="PainelBuscaAtiva">
             {
@@ -277,7 +283,7 @@ const PainelBuscaAtiva = ({
                 updateData={updateData}
                 tabela={tabela.data}
                 ordenacaoAplicada={ordenacaoAplicada}
-                handlePrintClick={handlePrintClick}
+                handlePrintClick={mostrarModalImpressao}
             />
             <TabelaHiperDia
                 colunas={tabela.colunas}
@@ -296,6 +302,34 @@ const PainelBuscaAtiva = ({
                     margin="0px"
                 />
             </Toast>
+            <ModalAlertControlled
+                display={showModalImpressao}
+                close={fecharModalImpressao}
+            >
+                <PersonalizacaoImpressao
+                    labels={{
+                        titulo: "PERSONALIZAR A IMPRESSÃO",
+                        personalizacaoPrincipal: {
+                            titulo: "Deseja fazer uma impressão personalizada por Equipes?",
+                            descricao: "A impressão personalizada agrupa os pacientes de acordo com as Equipes correspondentes. Qualquer filtrou ou ordenação selecionados anteriormente serão mantidos e aplicados dentro do agrupamento por equipes",
+                            opcoes: {
+                            agrupamentoSim: "Sim",
+                            agrupamentoNao: "Não",
+                            },
+                        },
+                        personalizacaoSecundaria: {
+                            titulo: "Outras personalizações de impressão:",
+                            recomendacao: "Recomendadas para distribuição para coordenadoras de equipe",
+                            opcoes: {
+                            separacaoGrupoPorFolha: "Imprimir grupos de pacientes por Equipes em folhas separadas",
+                            ordenacao: "Ordenar pacientes por ACS",
+                            },
+                        },
+                        botao: "IMPRIMIR LISTA",
+                    }}
+                    handleClose={fecharModalImpressao}
+                />
+            </ModalAlertControlled>
             {
                 showImpressao &&
                 <TabelaImpressao

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
@@ -1079,7 +1079,7 @@ Cito.args={
       agrupamentoNao: "Não, imprimir a lista como ela está.",
     },
     personalizacaoSecundaria: {
-      titulo: "Outras opções de impressão:",
+      titulo: "Outras opções de impressão por equipes:",
       recomendacao: "Ideal para distribuir listas para coordenadoras de equipe",
       separacaoGrupoPorFolha: "Também dividir equipes em folhas separadas",
       ordenacao: "Também ordenar listas por profissional responsável",

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
@@ -1043,7 +1043,7 @@ Hipertensao.args={
 export const Cito = Template.bind({});
 
 Cito.args={
-  painel : "cito",
+  painel : "aps",
   dadosFiltros : dadosFiltrosCito,
   tabela : {
       colunas : colunasCito,

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
@@ -716,13 +716,29 @@ const dadosFiltrosCito = [
 ]
 
 const dataCito = [
+      {
+        "paciente_nome": "MARIA DE SOUZA MACHADO",
+        "cidadao_cpf_dt_nascimento": "106.106.638-01",
+        "id_status_usuario": 15,
+        "vencimento_da_coleta": "-",
+        "prazo_proxima_coleta": "31/08/2023",
+        "idade": 5,
+        "id_faixa_etaria": 8,
+        "acs_nome": "Alessandra de Fatima Pereira",
+        "estabelecimento_cnes": "2879085",
+        "estabelecimento_nome": "Unidade de Saude da Familia Taboao",
+        "equipe_ine": "0002277573",
+        "ine_master": "0002277573",
+        "equipe_nome": "ESF GOIANA",
+        "dt_registro_producao_mais_recente" : "2023-10-22"
+    },
     {
         "paciente_nome": "ABIGAIR DE SOUZA BADA",
         "cidadao_cpf_dt_nascimento": "106.106.638-01",
         "id_status_usuario": 15,
         "vencimento_da_coleta": "-",
         "prazo_proxima_coleta": "31/08/2023",
-        "idade": 5,
+        "idade": 55,
         "id_faixa_etaria": 8,
         "acs_nome": "Alessandra de Fatima Pereira",
         "estabelecimento_cnes": "2879085",
@@ -763,6 +779,23 @@ const dataCito = [
         "ine_master": "0000369799",
         "equipe_nome": "ESF MAILASQUI 1.2",
         "dt_registro_producao_mais_recente" : "2023-10-22"
+
+    },
+    {
+      "paciente_nome": "CARLOS MEANDRO ANDRADE",
+      "cidadao_cpf_dt_nascimento": "100.941.638-39",
+      "id_status_usuario": 12,
+      "vencimento_da_coleta": "27/07/2025",
+      "prazo_proxima_coleta": "Em dia",
+      "idade": 47,
+      "id_faixa_etaria": 8,
+      "acs_nome": "Estela Ribeiro",
+      "estabelecimento_cnes": "2752522",
+      "estabelecimento_nome": "Posto de Saude de Mailasqui Sao Roque",
+      "equipe_ine": "0000369799",
+      "ine_master": "0000369799",
+      "equipe_nome": "ESF MAILASQUI 1.2",
+      "dt_registro_producao_mais_recente" : "2023-10-22"
 
     },
     {
@@ -1070,6 +1103,7 @@ Cito.args={
   }),
   onPrintClick: printDataCito,
   propAgrupamentoImpressao: "equipe_nome",
+  propOrdenacaoImpressao: "acs_nome",
   labelsModalImpressao: {
     titulo: "IMPRESSÃO POR EQUIPES",
     personalizacaoPrincipal: {

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
@@ -673,7 +673,7 @@ const dataDiabetes=[
 const dadosFiltrosCito = [
   {
     rotulo : "Filtrar por nome da equipe",
-    data :  ["ESF TABOAO 2","ESF GOIANA","ESF MAILASQUI 1.2"],
+    data :  ["ESF TABOAO 2","ESF GOIANA","ESF MAILASQUI 1.2","SEM EQUIPE RESPONSÁVEL"],
     filtro : "equipe_nome"
   },
   {
@@ -865,7 +865,58 @@ const dataCito = [
         "equipe_nome": "ESF GOIANA",
         "dt_registro_producao_mais_recente" : "2023-10-22"
 
-    }
+    },
+    {
+      "paciente_nome": "ADELIA OLIVEIRA",
+      "cidadao_cpf_dt_nascimento": "164.405.328-47",
+      "id_status_usuario": 12,
+      "vencimento_da_coleta": "15/02/2026",
+      "prazo_proxima_coleta": "Em dia",
+      "idade": 51,
+      "id_faixa_etaria": 8,
+      "acs_nome": "Luana Pereira",
+      "estabelecimento_cnes": "2793377",
+      "estabelecimento_nome": "Unidade de Saude da Familia Carmo Sao Roque",
+      "equipe_ine": "0",
+      "ine_master": "0000369802",
+      "equipe_nome": "SEM EQUIPE RESPONSÁVEL",
+      "dt_registro_producao_mais_recente" : "2023-10-22"
+
+  },
+  {
+      "paciente_nome": "ADA GOMES",
+      "cidadao_cpf_dt_nascimento": "167.328.578-35",
+      "id_status_usuario": 12,
+      "vencimento_da_coleta": "03/07/2026",
+      "prazo_proxima_coleta": "Em dia",
+      "idade": 49,
+      "id_faixa_etaria": 7,
+      "acs_nome": null,
+      "estabelecimento_cnes": "2752506",
+      "estabelecimento_nome": "Posto de Saude do Goiana",
+      "equipe_ine": "0",
+      "ine_master": "0001540971",
+      "equipe_nome": "SEM EQUIPE RESPONSÁVEL",
+      "dt_registro_producao_mais_recente" : "2023-10-22"
+
+  },
+  {
+      "paciente_nome": "ALICE SANTOS",
+      "cidadao_cpf_dt_nascimento": "167.328.578-35",
+      "id_status_usuario": 12,
+      "vencimento_da_coleta": "03/07/2026",
+      "prazo_proxima_coleta": "Em dia",
+      "idade": 49,
+      "id_faixa_etaria": 7,
+      "acs_nome": "Elisa Soares",
+      "estabelecimento_cnes": "2752506",
+      "estabelecimento_nome": "Posto de Saude do Goiana",
+      "equipe_ine": "0",
+      "ine_master": "0001540971",
+      "equipe_nome": "TATU",
+      "dt_registro_producao_mais_recente" : "2023-10-22"
+
+  }
 ]
 const datefiltrosDiabetes = [
   "dt_consulta_mais_recente",

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
@@ -1081,8 +1081,8 @@ Cito.args={
     personalizacaoSecundaria: {
       titulo: "Outras opções de impressão:",
       recomendacao: "Ideal para distribuir listas para coordenadoras de equipe",
-      separacaoGrupoPorFolha: "Dividir equipes em folhas separadas",
-      ordenacao: "Ordenar listas por profissional responsável",
+      separacaoGrupoPorFolha: "Também dividir equipes em folhas separadas",
+      ordenacao: "Também ordenar listas por profissional responsável",
     },
     botao: "IMPRIMIR LISTA",
   },

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
@@ -1069,4 +1069,5 @@ Cito.args={
     day: '2-digit'
   }),
   onPrintClick: printDataCito,
+  propAgrupamentoImpressao: "equipe_nome",
 }

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
@@ -1152,7 +1152,7 @@ Cito.args={
     month: '2-digit',
     day: '2-digit'
   }),
-  onPrintClick: printDataCito,
+  onPrintClick: () => console.log("onPrintClick"),
   propAgrupamentoImpressao: "equipe_nome",
   propOrdenacaoImpressao: "acs_nome",
   labelsModalImpressao: {

--- a/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
+++ b/componentes/PainelBuscaAtiva/PainelBuscaAtiva.stories.js
@@ -1070,4 +1070,20 @@ Cito.args={
   }),
   onPrintClick: printDataCito,
   propAgrupamentoImpressao: "equipe_nome",
+  labelsModalImpressao: {
+    titulo: "IMPRESSÃO POR EQUIPES",
+    personalizacaoPrincipal: {
+      titulo: "Deseja imprimir as listas divididas por Equipes?",
+      descricao: "Essa impressão agrupa os cidadãos de acordo com as Equipes correspondentes. Qualquer filtro ou ordenação selecionados anteriormente serão mantidos e aplicados dentro desses grupos.",
+      agrupamentoSim: "Sim, dividir listas por equipes.",
+      agrupamentoNao: "Não, imprimir a lista como ela está.",
+    },
+    personalizacaoSecundaria: {
+      titulo: "Outras opções de impressão:",
+      recomendacao: "Ideal para distribuir listas para coordenadoras de equipe",
+      separacaoGrupoPorFolha: "Dividir equipes em folhas separadas",
+      ordenacao: "Ordenar listas por profissional responsável",
+    },
+    botao: "IMPRIMIR LISTA",
+  },
 }

--- a/componentes/PainelBuscaAtiva/helpers/filter.js
+++ b/componentes/PainelBuscaAtiva/helpers/filter.js
@@ -20,3 +20,12 @@ export function filterByChoices(data, filterChoices) {
     return true;
   });
 }
+
+/**
+ * @param {*} filtros Array de filtros no formato {propriedade do filtro: valor do filtro}.
+ * @param {*} propriedade Propriedade do filtro a ser buscado no array de filtros.
+ * @returns Array com as opções de filtro encontradas a partir da propriedade. Caso filtros não existam, retorna um array vazio.
+ */
+export function buscarFiltroPorPropriedade(filtros, propriedade) {
+  return filtros.filter(item => item.hasOwnProperty(propriedade));
+}

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
@@ -4,27 +4,23 @@ import style from "./PersonalizacaoImpressao.module.css";
 import Image from "next/image";
 
 export const PersonalizacaoImpressao = ({
-  labels = {
+  titulo = "",
+  labelsPersonalizacaoPrincipal = {
     titulo: "",
-    personalizacaoPrincipal: {
-      titulo: "",
-      descricao: "",
-      opcoes: {
-        agrupamentoSim: "",
-        agrupamentoNao: "",
-      },
-    },
-    personalizacaoSecundaria: {
-      titulo: "",
-      recomendacao: "",
-      opcoes: {
-        separacaoGrupoPorFolha: "",
-        ordenacao: "",
-      },
-    },
-    botao: "",
+    descricao: "",
+    agrupamentoSim: "",
+    agrupamentoNao: "",
   },
-  handleClick = () => {},
+  labelsPersonalizacaoSecundaria = {
+    titulo: "",
+    recomendacao: "",
+    separacaoGrupoPorFolha: "",
+    ordenacao: "",
+  },
+  botao = {
+    label: "",
+    handleClick: () => {},
+  },
   handleClose = () => {},
 }) => {
   const valoresAgrupamento = { sim: "sim", nao: "não" };
@@ -60,15 +56,15 @@ export const PersonalizacaoImpressao = ({
           height={30}
           alt="Icone de brilho"
         />
-        <h4 className={style.Titulo}>{labels.titulo}</h4>
+        <h4 className={style.Titulo}>{titulo}</h4>
       </div>
 
       <h5 className={style.TituloPersonalizacaoPrincipal}>
-        {labels.personalizacaoPrincipal.titulo}
+        {labelsPersonalizacaoPrincipal.titulo}
       </h5>
 
       <p className={style.DescricaoPersonalizacaoPrincipal}>
-        {labels.personalizacaoPrincipal.descricao}
+        {labelsPersonalizacaoPrincipal.descricao}
       </p>
 
       <div className={style.OpcaoPersonalizacaoPrincipal}>
@@ -82,7 +78,7 @@ export const PersonalizacaoImpressao = ({
           id="agrupamentoSim"
         />
         <label htmlFor="agrupamentoSim">
-          {labels.personalizacaoPrincipal.opcoes.agrupamentoSim}
+          {labelsPersonalizacaoPrincipal.agrupamentoSim}
         </label>
       </div>
 
@@ -97,7 +93,7 @@ export const PersonalizacaoImpressao = ({
           id="agrupamentoNao"
         />
         <label htmlFor="agrupamentoNao">
-          {labels.personalizacaoPrincipal.opcoes.agrupamentoNao}
+          {labelsPersonalizacaoPrincipal.agrupamentoNao}
         </label>
       </div>
 
@@ -107,7 +103,7 @@ export const PersonalizacaoImpressao = ({
             <hr className={style.Linha}/>
 
             <h5 className={style.TituloPersonalizacoesSecundarias}>
-              {labels.personalizacaoSecundaria.titulo}
+              {labelsPersonalizacaoSecundaria.titulo}
             </h5>
 
             <div className={style.ContainerPersonalizacoesSecundarias}>
@@ -119,7 +115,7 @@ export const PersonalizacaoImpressao = ({
                   alt="Ícone de estrela"
                 />
                 <span className={style.TextoRecomendacao}>
-                  {labels.personalizacaoSecundaria.recomendacao}
+                  {labelsPersonalizacaoSecundaria.recomendacao}
                 </span>
               </div>
 
@@ -132,7 +128,7 @@ export const PersonalizacaoImpressao = ({
                   id="separacaoGrupoPorFolha"
                 />
                 <label htmlFor="separacaoGrupoPorFolha">
-                  {labels.personalizacaoSecundaria.opcoes.separacaoGrupoPorFolha}
+                  {labelsPersonalizacaoSecundaria.separacaoGrupoPorFolha}
                 </label>
               </div>
 
@@ -145,7 +141,7 @@ export const PersonalizacaoImpressao = ({
                   id="ordenacao"
                 />
                 <label htmlFor="ordenacao">
-                  {labels.personalizacaoSecundaria.opcoes.ordenacao}
+                  {labelsPersonalizacaoSecundaria.ordenacao}
                 </label>
               </div>
             </div>
@@ -155,8 +151,8 @@ export const PersonalizacaoImpressao = ({
 
       <div className={style.ContainerBotao}>
         <ButtonColorSubmitIcon
-          label={labels.botao}
-          submit={handleClick}
+          label={botao.label}
+          submit={botao.handleClick}
         />
       </div>
     </div>

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { ButtonColorSubmitIcon } from "../ButtonColor/ButtonColor";
 import style from "./PersonalizacaoImpressao.module.css";
 import Image from "next/image";
+import cx from "classnames";
 
 export const PersonalizacaoImpressao = ({
   titulo = "",
@@ -22,24 +23,10 @@ export const PersonalizacaoImpressao = ({
     handleClick: () => {},
   },
   handleClose = () => {},
+  handleChange = () => {},
+  valoresAgrupamento,
+  personalizacao,
 }) => {
-  const valoresAgrupamento = { sim: "sim", nao: "não" };
-
-  const [opcoes, setOpcoes] = useState({
-    agrupamento: valoresAgrupamento.sim,
-    separacaoGrupoPorFolha: false,
-    ordenacao: false,
-  });
-
-  function handleChange(e) {
-    const { name, value, checked, type } = e.target;
-
-    setOpcoes({
-      ...opcoes,
-      [name]: type === "checkbox" ? checked : value
-    });
-  }
-
   return (
     <div className={style.Container}>
       <div className={style.Close}>
@@ -52,18 +39,20 @@ export const PersonalizacaoImpressao = ({
       <div className={style.TituloContainer}>
         <Image
           src="https://media.graphassets.com/tkjDWpANQ9SzsdACBiEI"
-          width={30}
-          height={30}
+          width={28}
+          height={28}
           alt="Icone de brilho"
         />
-        <h4 className={style.Titulo}>{titulo}</h4>
+        <h4 className={cx(style.Titulo, style.ResetEspacamento)}>
+          {titulo}
+        </h4>
       </div>
 
-      <h5 className={style.TituloPersonalizacaoPrincipal}>
+      <h5 className={cx(style.TituloPersonalizacaoPrincipal, style.ResetEspacamento)}>
         {labelsPersonalizacaoPrincipal.titulo}
       </h5>
 
-      <p className={style.DescricaoPersonalizacaoPrincipal}>
+      <p className={cx(style.DescricaoPersonalizacaoPrincipal, style.ResetEspacamento)}>
         {labelsPersonalizacaoPrincipal.descricao}
       </p>
 
@@ -73,7 +62,7 @@ export const PersonalizacaoImpressao = ({
           className={style.InputPersonalizacaoPrincipal}
           type="radio"
           value={valoresAgrupamento.sim}
-          checked={opcoes.agrupamento === valoresAgrupamento.sim}
+          checked={personalizacao.agrupamento === valoresAgrupamento.sim}
           name="agrupamento"
           id="agrupamentoSim"
         />
@@ -88,7 +77,7 @@ export const PersonalizacaoImpressao = ({
           className={style.InputPersonalizacaoPrincipal}
           type="radio"
           value={valoresAgrupamento.nao}
-          checked={opcoes.agrupamento === valoresAgrupamento.nao}
+          checked={personalizacao.agrupamento === valoresAgrupamento.nao}
           name="agrupamento"
           id="agrupamentoNao"
         />
@@ -98,11 +87,11 @@ export const PersonalizacaoImpressao = ({
       </div>
 
       {
-        opcoes.agrupamento === valoresAgrupamento.sim && (
+        personalizacao.agrupamento === valoresAgrupamento.sim && (
           <>
             <hr className={style.Linha}/>
 
-            <h5 className={style.TituloPersonalizacoesSecundarias}>
+            <h5 className={cx(style.TituloPersonalizacoesSecundarias, style.ResetEspacamento)}>
               {labelsPersonalizacaoSecundaria.titulo}
             </h5>
 
@@ -123,7 +112,7 @@ export const PersonalizacaoImpressao = ({
                 <input
                   onChange={handleChange}
                   type="checkbox"
-                  checked={opcoes.separacaoGrupoPorFolha}
+                  checked={personalizacao.separacaoGrupoPorFolha}
                   name="separacaoGrupoPorFolha"
                   id="separacaoGrupoPorFolha"
                 />
@@ -136,7 +125,7 @@ export const PersonalizacaoImpressao = ({
                 <input
                   onChange={handleChange}
                   type="checkbox"
-                  checked={opcoes.ordenacao}
+                  checked={personalizacao.ordenacao}
                   name="ordenacao"
                   id="ordenacao"
                 />

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
@@ -1,32 +1,47 @@
-import React from "react";
+import React, { useState } from "react";
 import { ButtonColorSubmitIcon } from "../ButtonColor/ButtonColor";
 import style from "./PersonalizacaoImpressao.module.css";
 import Image from "next/image";
 import cx from "classnames";
 
-export const PersonalizacaoImpressao = ({
-  labels = {
+const DEFAULT_LABELS = {
+  titulo: "",
+  personalizacaoPrincipal: {
     titulo: "",
-    personalizacaoPrincipal: {
-      titulo: "",
-      descricao: "",
-      agrupamentoSim: "",
-      agrupamentoNao: "",
-    },
-    personalizacaoSecundaria: {
-      titulo: "",
-      recomendacao: "",
-      separacaoGrupoPorFolha: "",
-      ordenacao: "",
-    },
-    botao: "",
+    descricao: "",
+    agrupamentoSim: "",
+    agrupamentoNao: "",
   },
+  personalizacaoSecundaria: {
+    titulo: "",
+    recomendacao: "",
+    separacaoGrupoPorFolha: "",
+    ordenacao: "",
+  },
+  botao: "",
+};
+
+export const PersonalizacaoImpressao = ({
+  labels = DEFAULT_LABELS,
   handleClose = () => {},
-  handleChange = () => {},
   handleButtonClick = () => {},
   valoresAgrupamento,
-  personalizacao,
 }) => {
+  const [personalizacao, setPersonalizacao] = useState({
+    agrupamento: valoresAgrupamento.sim,
+    separacaoGrupoPorFolha: false,
+    ordenacao: false,
+  });
+
+  function handleChange(e) {
+    const { name, value, checked, type } = e.target;
+
+    setPersonalizacao({
+        ...personalizacao,
+        [name]: type === "checkbox" ? checked : value
+    });
+}
+
   return (
     <div className={style.Container}>
       <div className={style.Close}>
@@ -143,7 +158,7 @@ export const PersonalizacaoImpressao = ({
       <div className={style.ContainerBotao}>
         <ButtonColorSubmitIcon
           label={labels.botao}
-          submit={handleButtonClick}
+          submit={() => handleButtonClick(personalizacao)}
         />
       </div>
     </div>

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { ButtonColorSubmitIcon } from "../ButtonColor/ButtonColor";
 import style from "./PersonalizacaoImpressao.module.css";
 import Image from "next/image";
@@ -42,6 +42,7 @@ export const PersonalizacaoImpressao = ({
           width={28}
           height={28}
           alt="Icone de brilho"
+          className={style.IconeTitulo}
         />
         <h4 className={cx(style.Titulo, style.ResetEspacamento)}>
           {titulo}
@@ -102,6 +103,7 @@ export const PersonalizacaoImpressao = ({
                   width={14}
                   height={14}
                   alt="Ícone de estrela"
+                  className={style.IconeRecomendacao}
                 />
                 <span className={style.TextoRecomendacao}>
                   {labelsPersonalizacaoSecundaria.recomendacao}

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { ButtonColorSubmitIcon } from "../ButtonColor/ButtonColor";
 import style from "./PersonalizacaoImpressao.module.css";
+import Image from "next/image";
 
 export const PersonalizacaoImpressao = ({
   labels = {
@@ -57,7 +58,15 @@ export const PersonalizacaoImpressao = ({
         />
       </div>
 
-      <h4 className={style.Titulo}>{labels.titulo}</h4>
+      <div className={style.TituloContainer}>
+        <Image
+          src="https://media.graphassets.com/tkjDWpANQ9SzsdACBiEI"
+          width={32}
+          height={32}
+          alt="Picture of the author"
+        />
+        <h4 className={style.Titulo}>{labels.titulo}</h4>
+      </div>
 
       <h5 className={style.TituloPersonalizacaoPrincipal}>
         {labels.personalizacaoPrincipal.titulo}
@@ -108,6 +117,12 @@ export const PersonalizacaoImpressao = ({
 
             <div className={style.ContainerPersonalizacoesSecundarias}>
               <div className={style.Recomendacao}>
+                <Image
+                  src="https://media.graphassets.com/WMvmmV6JTKZ1OhELfymQ"
+                  width={14}
+                  height={14}
+                  alt="Picture of the author"
+                />
                 <span className={style.TextoRecomendacao}>
                   {labels.personalizacaoSecundaria.recomendacao}
                 </span>

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
@@ -37,10 +37,10 @@ export const PersonalizacaoImpressao = ({
     const { name, value, checked, type } = e.target;
 
     setPersonalizacao({
-        ...personalizacao,
-        [name]: type === "checkbox" ? checked : value
+      ...personalizacao,
+      [name]: type === "checkbox" ? checked : value
     });
-}
+  }
 
   return (
     <div className={style.Container}>

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
@@ -26,7 +26,6 @@ export const PersonalizacaoImpressao = ({
   },
   handleClick = () => {},
   handleClose = () => {},
-  // handleChange,
 }) => {
   const valoresAgrupamento = { sim: "sim", nao: "não" };
 
@@ -45,10 +44,6 @@ export const PersonalizacaoImpressao = ({
     });
   }
 
-  // function handleClick() {
-    
-  // }
-
   return (
     <div className={style.Container}>
       <div className={style.Close}>
@@ -61,9 +56,9 @@ export const PersonalizacaoImpressao = ({
       <div className={style.TituloContainer}>
         <Image
           src="https://media.graphassets.com/tkjDWpANQ9SzsdACBiEI"
-          width={32}
-          height={32}
-          alt="Picture of the author"
+          width={30}
+          height={30}
+          alt="Icone de brilho"
         />
         <h4 className={style.Titulo}>{labels.titulo}</h4>
       </div>
@@ -121,7 +116,7 @@ export const PersonalizacaoImpressao = ({
                   src="https://media.graphassets.com/WMvmmV6JTKZ1OhELfymQ"
                   width={14}
                   height={14}
-                  alt="Picture of the author"
+                  alt="Ícone de estrela"
                 />
                 <span className={style.TextoRecomendacao}>
                   {labels.personalizacaoSecundaria.recomendacao}

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
@@ -1,0 +1,154 @@
+import React, { useState } from "react";
+import { ButtonColorSubmitIcon } from "../ButtonColor/ButtonColor";
+import style from "./PersonalizacaoImpressao.module.css";
+
+export const PersonalizacaoImpressao = ({
+  labels = {
+    titulo: "",
+    personalizacaoPrincipal: {
+      titulo: "",
+      descricao: "",
+      opcoes: {
+        agrupamentoSim: "",
+        agrupamentoNao: "",
+      },
+    },
+    personalizacaoSecundaria: {
+      titulo: "",
+      recomendacao: "",
+      opcoes: {
+        separacaoGrupoPorFolha: "",
+        ordenacao: "",
+      },
+    },
+    botao: "",
+  },
+  handleClick = () => {},
+  handleClose = () => {},
+  // handleChange,
+}) => {
+  const valoresAgrupamento = { sim: "sim", nao: "não" };
+
+  const [opcoes, setOpcoes] = useState({
+    agrupamento: valoresAgrupamento.sim,
+    separacaoGrupoPorFolha: false,
+    ordenacao: false,
+  });
+
+  function handleChange(e) {
+    const { name, value, checked, type } = e.target;
+
+    setOpcoes({
+      ...opcoes,
+      [name]: type === "checkbox" ? checked : value
+    });
+  }
+
+  // function handleClick() {
+    
+  // }
+
+  return (
+    <div className={style.Container}>
+      <div className={style.Close}>
+        <a
+          className={style.ModalExit}
+          onClick={handleClose}
+        />
+      </div>
+
+      <h4 className={style.Titulo}>{labels.titulo}</h4>
+
+      <h5 className={style.TituloPersonalizacaoPrincipal}>
+        {labels.personalizacaoPrincipal.titulo}
+      </h5>
+
+      <p className={style.DescricaoPersonalizacaoPrincipal}>
+        {labels.personalizacaoPrincipal.descricao}
+      </p>
+
+      <div className={style.OpcaoPersonalizacaoPrincipal}>
+        <input
+          onChange={handleChange}
+          className={style.InputPersonalizacaoPrincipal}
+          type="radio"
+          value={valoresAgrupamento.sim}
+          checked={opcoes.agrupamento === valoresAgrupamento.sim}
+          name="agrupamento"
+          id="agrupamentoSim"
+        />
+        <label htmlFor="agrupamentoSim">
+          {labels.personalizacaoPrincipal.opcoes.agrupamentoSim}
+        </label>
+      </div>
+
+      <div className={style.OpcaoPersonalizacaoPrincipal}>
+        <input
+          onChange={handleChange}
+          className={style.InputPersonalizacaoPrincipal}
+          type="radio"
+          value={valoresAgrupamento.nao}
+          checked={opcoes.agrupamento === valoresAgrupamento.nao}
+          name="agrupamento"
+          id="agrupamentoNao"
+        />
+        <label htmlFor="agrupamentoNao">
+          {labels.personalizacaoPrincipal.opcoes.agrupamentoNao}
+        </label>
+      </div>
+
+      {
+        opcoes.agrupamento === valoresAgrupamento.sim && (
+          <>
+            <hr className={style.Linha}/>
+
+            <h5 className={style.TituloPersonalizacoesSecundarias}>
+              {labels.personalizacaoSecundaria.titulo}
+            </h5>
+
+            <div className={style.ContainerPersonalizacoesSecundarias}>
+              <div className={style.Recomendacao}>
+                <span className={style.TextoRecomendacao}>
+                  {labels.personalizacaoSecundaria.recomendacao}
+                </span>
+              </div>
+
+              <div className={style.OpcaoPersonalizacaoSecundaria}>
+                <input
+                  onChange={handleChange}
+                  type="checkbox"
+                  checked={opcoes.separacaoGrupoPorFolha}
+                  name="separacaoGrupoPorFolha"
+                  id="separacaoGrupoPorFolha"
+                />
+                <label htmlFor="separacaoGrupoPorFolha">
+                  {labels.personalizacaoSecundaria.opcoes.separacaoGrupoPorFolha}
+                </label>
+              </div>
+
+              <div className={style.OpcaoPersonalizacaoSecundaria}>
+                <input
+                  onChange={handleChange}
+                  type="checkbox"
+                  checked={opcoes.ordenacao}
+                  name="ordenacao"
+                  id="ordenacao"
+                />
+                <label htmlFor="ordenacao">
+                  {labels.personalizacaoSecundaria.opcoes.ordenacao}
+                </label>
+              </div>
+            </div>
+          </>
+        )
+      }
+
+      <div className={style.ContainerBotao}>
+        <ButtonColorSubmitIcon
+          label={labels.botao}
+          submit={handleClick}
+        />
+      </div>
+    </div>
+  )
+}

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.jsx
@@ -5,25 +5,25 @@ import Image from "next/image";
 import cx from "classnames";
 
 export const PersonalizacaoImpressao = ({
-  titulo = "",
-  labelsPersonalizacaoPrincipal = {
+  labels = {
     titulo: "",
-    descricao: "",
-    agrupamentoSim: "",
-    agrupamentoNao: "",
-  },
-  labelsPersonalizacaoSecundaria = {
-    titulo: "",
-    recomendacao: "",
-    separacaoGrupoPorFolha: "",
-    ordenacao: "",
-  },
-  botao = {
-    label: "",
-    handleClick: () => {},
+    personalizacaoPrincipal: {
+      titulo: "",
+      descricao: "",
+      agrupamentoSim: "",
+      agrupamentoNao: "",
+    },
+    personalizacaoSecundaria: {
+      titulo: "",
+      recomendacao: "",
+      separacaoGrupoPorFolha: "",
+      ordenacao: "",
+    },
+    botao: "",
   },
   handleClose = () => {},
   handleChange = () => {},
+  handleButtonClick = () => {},
   valoresAgrupamento,
   personalizacao,
 }) => {
@@ -45,16 +45,16 @@ export const PersonalizacaoImpressao = ({
           className={style.IconeTitulo}
         />
         <h4 className={cx(style.Titulo, style.ResetEspacamento)}>
-          {titulo}
+          {labels.titulo}
         </h4>
       </div>
 
       <h5 className={cx(style.TituloPersonalizacaoPrincipal, style.ResetEspacamento)}>
-        {labelsPersonalizacaoPrincipal.titulo}
+        {labels.personalizacaoPrincipal.titulo}
       </h5>
 
       <p className={cx(style.DescricaoPersonalizacaoPrincipal, style.ResetEspacamento)}>
-        {labelsPersonalizacaoPrincipal.descricao}
+        {labels.personalizacaoPrincipal.descricao}
       </p>
 
       <div className={style.OpcaoPersonalizacaoPrincipal}>
@@ -68,7 +68,7 @@ export const PersonalizacaoImpressao = ({
           id="agrupamentoSim"
         />
         <label htmlFor="agrupamentoSim">
-          {labelsPersonalizacaoPrincipal.agrupamentoSim}
+          {labels.personalizacaoPrincipal.agrupamentoSim}
         </label>
       </div>
 
@@ -83,7 +83,7 @@ export const PersonalizacaoImpressao = ({
           id="agrupamentoNao"
         />
         <label htmlFor="agrupamentoNao">
-          {labelsPersonalizacaoPrincipal.agrupamentoNao}
+          {labels.personalizacaoPrincipal.agrupamentoNao}
         </label>
       </div>
 
@@ -93,7 +93,7 @@ export const PersonalizacaoImpressao = ({
             <hr className={style.Linha}/>
 
             <h5 className={cx(style.TituloPersonalizacoesSecundarias, style.ResetEspacamento)}>
-              {labelsPersonalizacaoSecundaria.titulo}
+              {labels.personalizacaoSecundaria.titulo}
             </h5>
 
             <div className={style.ContainerPersonalizacoesSecundarias}>
@@ -106,7 +106,7 @@ export const PersonalizacaoImpressao = ({
                   className={style.IconeRecomendacao}
                 />
                 <span className={style.TextoRecomendacao}>
-                  {labelsPersonalizacaoSecundaria.recomendacao}
+                  {labels.personalizacaoSecundaria.recomendacao}
                 </span>
               </div>
 
@@ -119,7 +119,7 @@ export const PersonalizacaoImpressao = ({
                   id="separacaoGrupoPorFolha"
                 />
                 <label htmlFor="separacaoGrupoPorFolha">
-                  {labelsPersonalizacaoSecundaria.separacaoGrupoPorFolha}
+                  {labels.personalizacaoSecundaria.separacaoGrupoPorFolha}
                 </label>
               </div>
 
@@ -132,7 +132,7 @@ export const PersonalizacaoImpressao = ({
                   id="ordenacao"
                 />
                 <label htmlFor="ordenacao">
-                  {labelsPersonalizacaoSecundaria.ordenacao}
+                  {labels.personalizacaoSecundaria.ordenacao}
                 </label>
               </div>
             </div>
@@ -142,8 +142,8 @@ export const PersonalizacaoImpressao = ({
 
       <div className={style.ContainerBotao}>
         <ButtonColorSubmitIcon
-          label={botao.label}
-          submit={botao.handleClick}
+          label={labels.botao}
+          submit={handleButtonClick}
         />
       </div>
     </div>

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
@@ -1,0 +1,156 @@
+* {
+  margin: 0;
+  padding: 0;
+}
+
+.Container {
+  padding-top: 32px;
+  padding-right: 32px;
+  padding-left: 32px;
+  padding-bottom: 48px;
+  box-sizing: border-box;
+  font-family: 'Inter';
+  color: #1F1F1F;
+  width: 900px;
+  height: fit-content;
+  background-color: #fff;
+  border-radius: 20px;
+  position: relative;
+  z-index: 9000;
+}
+
+.ModalExit{
+  color:#fff;
+  background-color: black;
+  border-radius: 100%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+}
+
+.ModalExit:before{
+  content: "✖";
+  cursor: pointer;
+  padding:0.5em;
+}
+
+.Close{
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 24px;
+}
+
+.Titulo {
+  display: flex;
+  margin-bottom: 16px;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+  letter-spacing: -0.01em;
+  text-align: left;
+  color: #1D856C;
+}
+
+.TituloPersonalizacaoPrincipal {
+  font-size: 32px;
+  font-weight: 400;
+  line-height: 41.6px;
+  letter-spacing: -0.02em;
+  text-align: left;
+  margin-bottom: 24px;
+}
+
+.DescricaoPersonalizacaoPrincipal {
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+  letter-spacing: -0.01em;
+  text-align: left;
+  margin-bottom: 24px;
+}
+
+.OpcaoPersonalizacaoPrincipal {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 10px;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+  letter-spacing: -0.01em;
+  text-align: left;
+}
+
+.InputPersonalizacaoPrincipal {
+  width: 20px;
+  height: 20px;
+  padding: 0 2px;
+  /* essa cor é muito clara e deixa a input com baixo contrates, por isso parte da input fica com funco preto */
+  /* accent-color: #2EB280; */
+}
+
+.Linha {
+  margin: 24px 0;
+}
+
+.TituloPersonalizacoesSecundarias {
+  font-size: 24px;
+  font-weight: 400;
+  line-height: 31.2px;
+  letter-spacing: -0.02em;
+  text-align: left;
+  padding: 10px 0;
+  margin-bottom: 24px;
+}
+
+.ContainerPersonalizacoesSecundarias {
+  padding: 18px 11px 24px 11px;
+  border-radius: 8px;
+  border: 1.5px solid #916A20;
+}
+
+.OpcaoPersonalizacaoSecundaria {
+  display: flex;
+  gap: 10px;
+  padding: 0px 12px;
+  margin-top: 16px;
+}
+
+.ContainerPersonalizacoesSecundarias input {
+  width: 17px;
+  height: 19px;
+  padding: 1.19px 0px 1.19px 0px;
+  position: relative;
+}
+
+.ContainerBotao {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 24px;
+}
+
+.Recomendacao {
+  display: flex;
+  gap: 5px;
+  width: fit-content;
+  position: absolute;
+  z-index: 1000;
+  top: 480px;
+  padding: 3px 10px;
+  border-radius: 5px;
+  border: 1px solid #916A20;
+  background-color: #FFEFB9;
+}
+
+.TextoRecomendacao {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 19.5px;
+  text-align: left;
+  color: #4F3D0C;
+}

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
@@ -1,4 +1,4 @@
-* {
+.ResetEspacamento {
   margin: 0;
   padding: 0;
 }
@@ -53,7 +53,7 @@
 
 .Titulo {
   display: flex;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   line-height: 24px;
   letter-spacing: -0.01em;
@@ -153,7 +153,7 @@
   width: fit-content;
   position: absolute;
   z-index: 1000;
-  top: 487px;
+  top: 485px;
   padding: 3px 10px;
   border-radius: 5px;
   border: 1px solid #916A20;

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
@@ -89,8 +89,7 @@
   width: 20px;
   height: 20px;
   padding: 0 2px;
-  /* essa cor é muito clara e deixa a input com baixo contrates, por isso parte da input fica com funco preto */
-  /* accent-color: #2EB280; */
+  accent-color: #145C56;
 }
 
 .Linha {
@@ -118,6 +117,7 @@
   gap: 10px;
   padding: 0px 12px;
   margin-top: 16px;
+  accent-color: #145C56;
 }
 
 .ContainerPersonalizacoesSecundarias input {

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
@@ -95,6 +95,7 @@
   width: 20px;
   height: 20px;
   padding: 0 2px;
+  margin: 0;
   accent-color: #145C56;
 }
 
@@ -113,6 +114,7 @@
 }
 
 .ContainerPersonalizacoesSecundarias {
+  position: relative;
   padding: 18px 11px 24px 11px;
   border-radius: 8px;
   border: 1.5px solid #916A20;
@@ -136,6 +138,7 @@
   width: 17px;
   height: 19px;
   padding: 1.19px 0px 1.19px 0px;
+  margin: 0;
   position: relative;
 }
 
@@ -153,7 +156,7 @@
   width: fit-content;
   position: absolute;
   z-index: 1000;
-  top: 485px;
+  top: -8px;
   padding: 3px 10px;
   border-radius: 5px;
   border: 1px solid #916A20;
@@ -168,15 +171,150 @@
   color: #4F3D0C;
 }
 
-@media screen and (max-width: 1023px) {
+@media screen and (max-width: 1440px) {
+  .Container {
+    width: 800px;
+  }
+
+  .TituloContainer {
+    margin-bottom: 13px;
+  }
+
+  .Titulo {
+    font-size: 13px;
+    line-height: 20px;
+  }
+
+  .TituloPersonalizacaoPrincipal {
+    font-size: 25px;
+    line-height: 33px;
+    margin-bottom: 20px;
+  }
+
+  .DescricaoPersonalizacaoPrincipal {
+    font-size: 14px;
+    line-height: 20px;
+    margin-bottom: 20px;
+  }
+
+  .OpcaoPersonalizacaoPrincipal {
+    padding: 8px 10px;
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  .InputPersonalizacaoPrincipal {
+    width: 18px;
+    height: 18px;
+    padding: 0;
+  }
+
+  .TituloPersonalizacoesSecundarias {
+    font-size: 20px;
+    line-height: 25px;
+    padding: 8px 0;
+    margin-bottom: 20px;
+  }
+
+  .Linha {
+    margin: 17px 0;
+  }
+
+  .OpcaoPersonalizacaoSecundaria {
+    padding: 0px 9px;
+    margin-top: 14px;
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  .ContainerPersonalizacoesSecundarias {
+    padding: 15px 9px 21px 9px;
+  }
+
+  .Close{
+    margin-bottom: 20px;
+  }
+
+  .Recomendacao {
+    padding: 3px 8px;
+  }
+
+  .TextoRecomendacao {
+    font-size: 12px;
+    line-height: 17px;
+  }
+
+  .ContainerPersonalizacoesSecundarias input {
+    width: 15px;
+    height: 17px;
+    padding: 0;
+  }
+}
+
+@media screen and (max-width: 1024px) {
+  .Container {
+    width: 80%;
+  }
+
+  .IconeTitulo {
+    width: 24px;
+    height: 24px;
+  }
+
+  .TituloContainer {
+    margin-bottom: 11px;
+  }
+
+  .TituloPersonalizacaoPrincipal {
+    font-size: 23px;
+    line-height: 31px;
+    margin-bottom: 18px;
+  }
+
+  .DescricaoPersonalizacaoPrincipal {
+    margin-bottom: 18px;
+  }
+
+  .OpcaoPersonalizacaoPrincipal {
+    padding: 6px 10px;
+  }
+
+  .TituloPersonalizacoesSecundarias {
+    font-size: 18px;
+    line-height: 23px;
+    padding: 6px 0;
+    margin-bottom: 18px;
+  }
+
+  .Linha {
+    margin: 16px 0;
+  }
+
+  .OpcaoPersonalizacaoSecundaria {
+    margin-top: 12px;
+  }
+
+  .ContainerPersonalizacoesSecundarias {
+    padding: 15px 9px 19px 9px;
+  }
+
+  .Close{
+    margin-bottom: 18px;
+  }
+}
+
+@media screen and (max-width: 768px) {
   .Container {
     width: 90%;
+    padding-top: 26px;
+    padding-right: 26px;
+    padding-left: 26px;
+    padding-bottom: 34px;
   }
 }
 
 @media screen and (max-width: 360px) {
   .Container {
-    width: 90%;
     padding: 20px;
   }
 
@@ -187,20 +325,17 @@
   .Titulo {
     font-size: 12px;
     line-height: 16px;
-    letter-spacing: -0.01em;
   }
 
   .TituloPersonalizacaoPrincipal {
     font-size: 18px;
     line-height: 22px;
-    letter-spacing: -0.02em;
     margin-bottom: 16px;
   }
 
   .DescricaoPersonalizacaoPrincipal {
     font-size: 12px;
     line-height: 16px;
-    letter-spacing: -0.01em;
     margin-bottom: 16px;
   }
 
@@ -209,13 +344,11 @@
     font-size: 12px;
     font-weight: 400;
     line-height: 16px;
-    letter-spacing: -0.01em;
   }
 
   .TituloPersonalizacoesSecundarias {
     font-size: 16px;
     line-height: 20px;
-    letter-spacing: -0.02em;
     padding: 6px 0;
     margin-bottom: 24px;
   }
@@ -229,7 +362,6 @@
     margin-top: 12px;
     font-size: 12px;
     line-height: 16px;
-    letter-spacing: -0.01em;
   }
 
   .ContainerPersonalizacoesSecundarias {
@@ -241,9 +373,9 @@
   }
 
   .Recomendacao {
-    top: 397px;
     padding: 3px 6px;
-    width: 70%;
+    width: 90%;
+    top: -18px;
   }
 
   .TextoRecomendacao {
@@ -258,5 +390,15 @@
   .ContainerPersonalizacoesSecundarias input {
     width: 14px;
     height: 14px;
+  }
+
+  .IconeTitulo {
+    width: 18px;
+    height: 18px;
+  }
+
+  .IconeRecomendacao {
+    width: 13px;
+    height: 13px;
   }
 }

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
@@ -120,10 +120,16 @@
 
 .OpcaoPersonalizacaoSecundaria {
   display: flex;
+  align-items: center;
   gap: 10px;
   padding: 0px 12px;
   margin-top: 16px;
   accent-color: #145C56;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+  letter-spacing: -0.01em;
+  text-align: left;
 }
 
 .ContainerPersonalizacoesSecundarias input {
@@ -147,7 +153,7 @@
   width: fit-content;
   position: absolute;
   z-index: 1000;
-  top: 480px;
+  top: 487px;
   padding: 3px 10px;
   border-radius: 5px;
   border: 1px solid #916A20;
@@ -160,4 +166,97 @@
   line-height: 19.5px;
   text-align: left;
   color: #4F3D0C;
+}
+
+@media screen and (max-width: 1023px) {
+  .Container {
+    width: 90%;
+  }
+}
+
+@media screen and (max-width: 360px) {
+  .Container {
+    width: 90%;
+    padding: 20px;
+  }
+
+  .TituloContainer {
+    margin-bottom: 10px;
+  }
+
+  .Titulo {
+    font-size: 12px;
+    line-height: 16px;
+    letter-spacing: -0.01em;
+  }
+
+  .TituloPersonalizacaoPrincipal {
+    font-size: 18px;
+    line-height: 22px;
+    letter-spacing: -0.02em;
+    margin-bottom: 16px;
+  }
+
+  .DescricaoPersonalizacaoPrincipal {
+    font-size: 12px;
+    line-height: 16px;
+    letter-spacing: -0.01em;
+    margin-bottom: 16px;
+  }
+
+  .OpcaoPersonalizacaoPrincipal {
+    padding: 6px;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 16px;
+    letter-spacing: -0.01em;
+  }
+
+  .TituloPersonalizacoesSecundarias {
+    font-size: 16px;
+    line-height: 20px;
+    letter-spacing: -0.02em;
+    padding: 6px 0;
+    margin-bottom: 24px;
+  }
+
+  .Linha {
+    margin: 10px 0;
+  }
+
+  .OpcaoPersonalizacaoSecundaria {
+    padding: 0px 6px;
+    margin-top: 12px;
+    font-size: 12px;
+    line-height: 16px;
+    letter-spacing: -0.01em;
+  }
+
+  .ContainerPersonalizacoesSecundarias {
+    padding: 12px 8px 18px 8px;
+  }
+
+  .Close{
+    margin-bottom: 16px;
+  }
+
+  .Recomendacao {
+    top: 397px;
+    padding: 3px 6px;
+    width: 70%;
+  }
+
+  .TextoRecomendacao {
+    font-size: 10px;
+    line-height: 14px;
+  }
+
+  .ContainerBotao {
+    margin-top: 16px;
+  }
+
+  .ContainerPersonalizacoesSecundarias input {
+    width: 14px;
+    height: 14px;
+  }
 }

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
@@ -7,7 +7,7 @@
   padding-top: 32px;
   padding-right: 32px;
   padding-left: 32px;
-  padding-bottom: 48px;
+  padding-bottom: 40px;
   box-sizing: border-box;
   font-family: 'Inter';
   color: #1F1F1F;

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
@@ -44,9 +44,15 @@
   margin-bottom: 24px;
 }
 
+.TituloContainer {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
 .Titulo {
   display: flex;
-  margin-bottom: 16px;
   font-size: 16px;
   font-weight: 400;
   line-height: 24px;
@@ -137,6 +143,7 @@
 .Recomendacao {
   display: flex;
   gap: 5px;
+  align-items: center;
   width: fit-content;
   position: absolute;
   z-index: 1000;

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.module.css
@@ -180,11 +180,6 @@
     margin-bottom: 13px;
   }
 
-  .Titulo {
-    font-size: 13px;
-    line-height: 20px;
-  }
-
   .TituloPersonalizacaoPrincipal {
     font-size: 25px;
     line-height: 33px;
@@ -254,11 +249,6 @@
 @media screen and (max-width: 1024px) {
   .Container {
     width: 80%;
-  }
-
-  .IconeTitulo {
-    width: 24px;
-    height: 24px;
   }
 
   .TituloContainer {

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.stories.js
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.stories.js
@@ -33,22 +33,22 @@ const Template = (args) => {
 export const Default = Template.bind({});
 
 Default.args = {
-  titulo: "PERSONALIZAR A IMPRESSÃO",
-  labelsPersonalizacaoPrincipal: {
-    titulo: "Deseja fazer uma impressão personalizada por Equipes?",
-    descricao: "A impressão personalizada agrupa os pacientes de acordo com as Equipes correspondentes. Qualquer filtrou ou ordenação selecionados anteriormente serão mantidos e aplicados dentro do agrupamento por equipes",
-    agrupamentoSim: "Sim",
-    agrupamentoNao: "Não",
+  labels: {
+    titulo: "PERSONALIZAR A IMPRESSÃO",
+    personalizacaoPrincipal: {
+      titulo: "Deseja fazer uma impressão personalizada por Equipes?",
+      descricao: "A impressão personalizada agrupa os pacientes de acordo com as Equipes correspondentes. Qualquer filtrou ou ordenação selecionados anteriormente serão mantidos e aplicados dentro do agrupamento por equipes",
+      agrupamentoSim: "Sim",
+      agrupamentoNao: "Não",
+    },
+    personalizacaoSecundaria: {
+      titulo: "Outras personalizações de impressão:",
+      recomendacao: "Recomendadas para distribuição para coordenadoras de equipe",
+      separacaoGrupoPorFolha: "Imprimir grupos de pacientes por Equipes em folhas separadas",
+      ordenacao: "Ordenar pacientes por ACS",
+    },
+    botao: "IMPRIMIR LISTA",
   },
-  labelsPersonalizacaoSecundaria: {
-    titulo: "Outras personalizações de impressão:",
-    recomendacao: "Recomendadas para distribuição para coordenadoras de equipe",
-    separacaoGrupoPorFolha: "Imprimir grupos de pacientes por Equipes em folhas separadas",
-    ordenacao: "Ordenar pacientes por ACS",
-  },
-  botao: {
-    label: "IMPRIMIR LISTA",
-    handleClick: () => {},
-  },
+  handleButtonClick: () => {},
   handleClose: () => console.log("close")
 }

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.stories.js
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.stories.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { PersonalizacaoImpressao } from './PersonalizacaoImpressao';
+
+export default {
+  title: "Componentes/PersonalizacaoImpressao",
+  component: PersonalizacaoImpressao,
+  argTypes: {
+  },
+};
+
+const Template = (args) => <PersonalizacaoImpressao {...args}/>
+
+export const Default = Template.bind({});
+
+Default.args = {
+  labels: {
+    titulo: "PERSONALIZAR A IMPRESSÃO",
+    personalizacaoPrincipal: {
+      titulo: "Deseja fazer uma impressão personalizada por Equipes?",
+      descricao: "A impressão personalizada agrupa os pacientes de acordo com as Equipes correspondentes. Qualquer filtrou ou ordenação selecionados anteriormente serão mantidos e aplicados dentro do agrupamento por equipes",
+      opcoes: {
+        agrupamentoSim: "Sim",
+        agrupamentoNao: "Não",
+      },
+    },
+    personalizacaoSecundaria: {
+      titulo: "Outras personalizações de impressão:",
+      recomendacao: "Recomendadas para distribuição para coordenadoras de equipe",
+      opcoes: {
+        separacaoGrupoPorFolha: "Imprimir grupos de pacientes por Equipes em folhas separadas",
+        ordenacao: "Ordenar pacientes por ACS",
+      },
+    },
+    botao: "IMPRIMIR LISTA",
+  },
+  handleClick: () => {},
+  handleClose: () => console.log("close")
+}

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.stories.js
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.stories.js
@@ -13,8 +13,8 @@ const VALORES_AGRUPAMENTO_IMPRESSAO = { sim: "sim", nao: "não" };
 const Template = (args) => {
   const [personalizacao, setPersonalizacao] = useState({
     agrupamento: VALORES_AGRUPAMENTO_IMPRESSAO.sim,
-      separacaoGrupoPorFolha: false,
-      ordenacao: false,
+    separacaoGrupoPorFolha: false,
+    ordenacao: false,
   });
 
   args["personalizacao"] = personalizacao;

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.stories.js
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { PersonalizacaoImpressao } from './PersonalizacaoImpressao';
 
 export default {
@@ -8,7 +8,27 @@ export default {
   },
 };
 
-const Template = (args) => <PersonalizacaoImpressao {...args}/>
+const VALORES_AGRUPAMENTO_IMPRESSAO = { sim: "sim", nao: "não" };
+
+const Template = (args) => {
+  const [personalizacao, setPersonalizacao] = useState({
+    agrupamento: VALORES_AGRUPAMENTO_IMPRESSAO.sim,
+      separacaoGrupoPorFolha: false,
+      ordenacao: false,
+  });
+
+  args["personalizacao"] = personalizacao;
+  args["valoresAgrupamento"] = VALORES_AGRUPAMENTO_IMPRESSAO;
+  args["handleChange"] = (e) => {
+    const { name, value, checked, type } = e.target;
+
+    setPersonalizacao({
+      ...personalizacao,
+      [name]: type === "checkbox" ? checked : value
+    });
+  }
+  return <PersonalizacaoImpressao {...args}/>
+}
 
 export const Default = Template.bind({});
 

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.stories.js
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.stories.js
@@ -13,26 +13,22 @@ const Template = (args) => <PersonalizacaoImpressao {...args}/>
 export const Default = Template.bind({});
 
 Default.args = {
-  labels: {
-    titulo: "PERSONALIZAR A IMPRESSÃO",
-    personalizacaoPrincipal: {
-      titulo: "Deseja fazer uma impressão personalizada por Equipes?",
-      descricao: "A impressão personalizada agrupa os pacientes de acordo com as Equipes correspondentes. Qualquer filtrou ou ordenação selecionados anteriormente serão mantidos e aplicados dentro do agrupamento por equipes",
-      opcoes: {
-        agrupamentoSim: "Sim",
-        agrupamentoNao: "Não",
-      },
-    },
-    personalizacaoSecundaria: {
-      titulo: "Outras personalizações de impressão:",
-      recomendacao: "Recomendadas para distribuição para coordenadoras de equipe",
-      opcoes: {
-        separacaoGrupoPorFolha: "Imprimir grupos de pacientes por Equipes em folhas separadas",
-        ordenacao: "Ordenar pacientes por ACS",
-      },
-    },
-    botao: "IMPRIMIR LISTA",
+  titulo: "PERSONALIZAR A IMPRESSÃO",
+  labelsPersonalizacaoPrincipal: {
+    titulo: "Deseja fazer uma impressão personalizada por Equipes?",
+    descricao: "A impressão personalizada agrupa os pacientes de acordo com as Equipes correspondentes. Qualquer filtrou ou ordenação selecionados anteriormente serão mantidos e aplicados dentro do agrupamento por equipes",
+    agrupamentoSim: "Sim",
+    agrupamentoNao: "Não",
   },
-  handleClick: () => {},
+  labelsPersonalizacaoSecundaria: {
+    titulo: "Outras personalizações de impressão:",
+    recomendacao: "Recomendadas para distribuição para coordenadoras de equipe",
+    separacaoGrupoPorFolha: "Imprimir grupos de pacientes por Equipes em folhas separadas",
+    ordenacao: "Ordenar pacientes por ACS",
+  },
+  botao: {
+    label: "IMPRIMIR LISTA",
+    handleClick: () => {},
+  },
   handleClose: () => console.log("close")
 }

--- a/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.stories.js
+++ b/componentes/PersonalizacaoImpressao/PersonalizacaoImpressao.stories.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { PersonalizacaoImpressao } from './PersonalizacaoImpressao';
 
 export default {
@@ -10,25 +10,7 @@ export default {
 
 const VALORES_AGRUPAMENTO_IMPRESSAO = { sim: "sim", nao: "não" };
 
-const Template = (args) => {
-  const [personalizacao, setPersonalizacao] = useState({
-    agrupamento: VALORES_AGRUPAMENTO_IMPRESSAO.sim,
-    separacaoGrupoPorFolha: false,
-    ordenacao: false,
-  });
-
-  args["personalizacao"] = personalizacao;
-  args["valoresAgrupamento"] = VALORES_AGRUPAMENTO_IMPRESSAO;
-  args["handleChange"] = (e) => {
-    const { name, value, checked, type } = e.target;
-
-    setPersonalizacao({
-      ...personalizacao,
-      [name]: type === "checkbox" ? checked : value
-    });
-  }
-  return <PersonalizacaoImpressao {...args}/>
-}
+const Template = (args) => <PersonalizacaoImpressao {...args}/>
 
 export const Default = Template.bind({});
 
@@ -50,5 +32,6 @@ Default.args = {
     botao: "IMPRIMIR LISTA",
   },
   handleButtonClick: () => {},
-  handleClose: () => console.log("close")
+  handleClose: () => console.log("close"),
+  valoresAgrupamento: VALORES_AGRUPAMENTO_IMPRESSAO,
 }

--- a/componentes/TabelaHiperDia/TabelaHiperDia.jsx
+++ b/componentes/TabelaHiperDia/TabelaHiperDia.jsx
@@ -487,7 +487,7 @@ const selecionar_status_usuario_descricao = (value,status_usuario_descricao)=> {
         </div>
         {divisao_dados
           ? (
-            Object.keys(divisao_por_equipes).map((registro,index)=>{
+            Object.keys(divisao_por_equipes).sort().map((registro,index)=>{
                 return <div style={{breakBefore: index > 0 ? "page" : ""}}>
                   <p>{registro}</p>
                   <TabelaUnitaria

--- a/componentes/TabelaHiperDia/TabelaHiperDia.jsx
+++ b/componentes/TabelaHiperDia/TabelaHiperDia.jsx
@@ -443,9 +443,15 @@ const selecionar_status_usuario_descricao = (value,status_usuario_descricao)=> {
       const valorAtualMaiusculo = String(atual).toUpperCase() ?? "";
       const valorSeguinteMaiusculo = String(seguinte).toUpperCase() ?? "";
 
-      return valorSeguinteMaiusculo === "SEM EQUIPE RESPONSÁVEL"
-        ? -1
-        : valorAtualMaiusculo.localeCompare(valorSeguinteMaiusculo);
+      if (valorSeguinteMaiusculo === "SEM EQUIPE RESPONSÁVEL") {
+        return -1
+      }
+
+      if (valorAtualMaiusculo === "SEM EQUIPE RESPONSÁVEL") {
+        return 1;
+      }
+
+      return valorAtualMaiusculo.localeCompare(valorSeguinteMaiusculo);
     }
 
     return (

--- a/componentes/TabelaHiperDia/TabelaHiperDia.jsx
+++ b/componentes/TabelaHiperDia/TabelaHiperDia.jsx
@@ -485,19 +485,30 @@ const selecionar_status_usuario_descricao = (value,status_usuario_descricao)=> {
             })
           }
         </div>
-        {
-          Object.keys(divisao_por_equipes).map((registro,index)=>{
-              return <div style={{breakBefore: index > 0 ? "page" : ""}}>
-                <p>{registro}</p>
-                <TabelaUnitaria
-                  data = {divisao_por_equipes[registro]}
-                  colunas = {colunas}
-                  status_usuario_descricao = {status_usuario_descricao}
-                  fontFamily = "Inter"
-                  indexTabela={index}
-                />
-              </div>
-          })
+        {divisao_dados
+          ? (
+            Object.keys(divisao_por_equipes).map((registro,index)=>{
+                return <div style={{breakBefore: index > 0 ? "page" : ""}}>
+                  <p>{registro}</p>
+                  <TabelaUnitaria
+                    data = {divisao_por_equipes[registro]}
+                    colunas = {colunas}
+                    status_usuario_descricao = {status_usuario_descricao}
+                    fontFamily = "Inter"
+                    indexTabela={index}
+                  />
+                </div>
+            })
+          )
+          : (
+            <TabelaUnitaria
+              data = {data}
+              colunas = {colunas}
+              status_usuario_descricao = {status_usuario_descricao}
+              fontFamily = "Inter"
+              indexTabela={0}
+            />
+          )
         }
       </div>
     );

--- a/componentes/TabelaHiperDia/TabelaHiperDia.jsx
+++ b/componentes/TabelaHiperDia/TabelaHiperDia.jsx
@@ -428,18 +428,20 @@ const selecionar_status_usuario_descricao = (value,status_usuario_descricao)=> {
     fontFamily = "Inter"
   }) => {
     const filtros_aplicados = ["status da coleta coleta em dia", "status da coleta Vence no final do quadrimestre"]
-    const divisao_por_equipes = data.reduce((acumulador, objetoAtual) => {
-      const { equipe_nome } = objetoAtual;
-      if (!acumulador[equipe_nome]) {
-        acumulador[equipe_nome] = [];
-      }
-      acumulador[equipe_nome].push(objetoAtual);
-      return acumulador;
-    }, {});
+    const divisao_por_equipes = divisao_dados
+      ? data.reduce((acumulador, objetoAtual) => {
+        const { equipe_nome } = objetoAtual;
+        if (!acumulador[equipe_nome]) {
+          acumulador[equipe_nome] = [];
+        }
+        acumulador[equipe_nome].push(objetoAtual);
+        return acumulador;
+      }, {})
+      : {};
 
     function ordenarEquipes(atual, seguinte) {
-      const valorAtualMaiusculo = String(atual).toUpperCase();
-      const valorSeguinteMaiusculo = String(seguinte).toUpperCase();
+      const valorAtualMaiusculo = String(atual).toUpperCase() ?? "";
+      const valorSeguinteMaiusculo = String(seguinte).toUpperCase() ?? "";
 
       return valorSeguinteMaiusculo === "SEM EQUIPE RESPONSÁVEL"
         ? -1

--- a/componentes/TabelaHiperDia/TabelaHiperDia.jsx
+++ b/componentes/TabelaHiperDia/TabelaHiperDia.jsx
@@ -436,6 +436,16 @@ const selecionar_status_usuario_descricao = (value,status_usuario_descricao)=> {
       acumulador[equipe_nome].push(objetoAtual);
       return acumulador;
     }, {});
+
+    function ordenarEquipes(atual, seguinte) {
+      const valorAtualMaiusculo = String(atual).toUpperCase();
+      const valorSeguinteMaiusculo = String(seguinte).toUpperCase();
+
+      return valorSeguinteMaiusculo === "SEM EQUIPE RESPONSÁVEL"
+        ? -1
+        : valorAtualMaiusculo.localeCompare(valorSeguinteMaiusculo);
+    }
+
     return (
       <div 
         ref={targetRef}
@@ -487,7 +497,7 @@ const selecionar_status_usuario_descricao = (value,status_usuario_descricao)=> {
         </div>
         {divisao_dados
           ? (
-            Object.keys(divisao_por_equipes).sort().map((registro,index)=>{
+            Object.keys(divisao_por_equipes).sort(ordenarEquipes).map((registro,index)=>{
                 return <div style={{breakBefore: index > 0 ? "page" : ""}}>
                   <p>{registro}</p>
                   <TabelaUnitaria

--- a/componentes/TabelaHiperDia/TabelaHiperDia.jsx
+++ b/componentes/TabelaHiperDia/TabelaHiperDia.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { DataGrid, ptBR } from '@mui/x-data-grid';
 import style from "./TabelaHiperDia.module.css";
+import * as utils from "../utils";
 
 export const VERIFICADO = "https://media.graphassets.com/wOzzseVhRriXENS9OhcG";
 export const ATENCAO = "https://media.graphassets.com/NPk8ggUoQzK18KSyAGL6";
@@ -439,21 +440,6 @@ const selecionar_status_usuario_descricao = (value,status_usuario_descricao)=> {
       }, {})
       : {};
 
-    function ordenarEquipes(atual, seguinte) {
-      const valorAtualMaiusculo = String(atual).toUpperCase() ?? "";
-      const valorSeguinteMaiusculo = String(seguinte).toUpperCase() ?? "";
-
-      if (valorSeguinteMaiusculo === "SEM EQUIPE RESPONSÁVEL") {
-        return -1
-      }
-
-      if (valorAtualMaiusculo === "SEM EQUIPE RESPONSÁVEL") {
-        return 1;
-      }
-
-      return valorAtualMaiusculo.localeCompare(valorSeguinteMaiusculo);
-    }
-
     return (
       <div 
         ref={targetRef}
@@ -505,7 +491,7 @@ const selecionar_status_usuario_descricao = (value,status_usuario_descricao)=> {
         </div>
         {divisao_dados
           ? (
-            Object.keys(divisao_por_equipes).sort(ordenarEquipes).map((registro,index)=>{
+            Object.keys(divisao_por_equipes).sort(utils.ordenarEquipes).map((registro,index)=>{
                 return <div style={{breakBefore: index > 0 ? "page" : ""}}>
                   <p>{registro}</p>
                   <TabelaUnitaria

--- a/componentes/utils/impressaoPersonalizada.js
+++ b/componentes/utils/impressaoPersonalizada.js
@@ -1,0 +1,16 @@
+const ULTIMA_EQUIPE = "SEM EQUIPE RESPONSÁVEL";
+
+export function ordenarEquipes(atual, seguinte) {
+  const valorAtualMaiusculo = String(atual).toUpperCase() ?? "";
+  const valorSeguinteMaiusculo = String(seguinte).toUpperCase() ?? "";
+
+  if (valorSeguinteMaiusculo === ULTIMA_EQUIPE) {
+    return -1
+  }
+
+  if (valorAtualMaiusculo === ULTIMA_EQUIPE) {
+    return 1;
+  }
+
+  return valorAtualMaiusculo.localeCompare(valorSeguinteMaiusculo);
+}

--- a/componentes/utils/index.js
+++ b/componentes/utils/index.js
@@ -1,0 +1,1 @@
+export * from "./impressaoPersonalizada";


### PR DESCRIPTION
### Contexto
Com a nova impressão de COAPS, foi adicionada a etapa de personalização que é feita no modal de impressão.

### Objetivos
- Criar e usar o o modal de impressão no PainelBuscaAtiva
- Criar função helper que verifica a quantidade de equipes selecionada para controlar a exibição do modal

### Checklist de validação
- [ ] O modal de impressão não é exibido quando o há exatamente uma equipe filtrada
- [ ] O modal de impressão funciona de acordo com o [protótipo](https://www.figma.com/design/QI3Nc654UEHz0Um8Avk5R4/AL--%3E-Impress%C3%A3o-de-listas?node-id=3033-11568&t=XiP8Uy4kopyJQTMb-0)